### PR TITLE
refactor: extract PlantCreateForm logic into usePlantCreateForm hook

### DIFF
--- a/apps/web/features/plants/components/organisms/plant-create-form/plant-create-form.tsx
+++ b/apps/web/features/plants/components/organisms/plant-create-form/plant-create-form.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { PLANT_STATUS } from '@/features/plants/constants/plant-status';
+import { usePlantCreateForm } from '@/features/plants/hooks/use-plant-create-form/use-plant-create-form';
 import { Button } from '@/shared/components/ui/button';
 import {
 	Dialog,
@@ -26,12 +27,8 @@ import {
 	SelectValue,
 } from '@/shared/components/ui/select';
 import { Textarea } from '@/shared/components/ui/textarea';
-import {
-	createPlantCreateSchema,
-	PlantCreateFormValues,
-} from 'features/plants/schemas/plant-create/plant-create.schema';
+import { PlantCreateFormValues } from 'features/plants/schemas/plant-create/plant-create.schema';
 import { useTranslations } from 'next-intl';
-import { useMemo, useState } from 'react';
 
 interface PlantCreateFormProps {
 	open: boolean;
@@ -54,82 +51,29 @@ export function PlantCreateForm({
 }: PlantCreateFormProps) {
 	const t = useTranslations();
 
-	// Create schema with translations
-	const createSchema = useMemo(
-		() => createPlantCreateSchema((key: string) => t(key)),
-		[t],
-	);
-
-	// Form state
-	const [selectedGrowingUnitId, setSelectedGrowingUnitId] = useState<string>(
-		initialGrowingUnitId || '',
-	);
-	const [name, setName] = useState('');
-	const [species, setSpecies] = useState('');
-	const [plantedDate, setPlantedDate] = useState<Date>(new Date());
-	const [notes, setNotes] = useState('');
-	const [status, setStatus] = useState<PlantCreateFormValues['status']>(
-		PLANT_STATUS.PLANTED,
-	);
-	const [formErrors, setFormErrors] = useState<
-		Record<string, { message?: string }>
-	>({});
-
-	const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
-		e.preventDefault();
-
-		// Use selected growing unit ID or the provided one
-		const finalGrowingUnitId =
-			selectedGrowingUnitId || initialGrowingUnitId || '';
-
-		// Validate form
-		const result = createSchema.safeParse({
-			name,
-			species,
-			plantedDate,
-			notes: notes || undefined,
-			status,
-			growingUnitId: finalGrowingUnitId,
-		});
-
-		if (!result.success) {
-			const errors: Record<string, { message?: string }> = {};
-			result.error.issues.forEach((err) => {
-				if (err.path[0]) {
-					errors[err.path[0] as string] = { message: err.message };
-				}
-			});
-			setFormErrors(errors);
-			return;
-		}
-
-		setFormErrors({});
-		await onSubmit(result.data);
-		if (!error) {
-			// Reset form
-			setSelectedGrowingUnitId(initialGrowingUnitId || '');
-			setName('');
-			setSpecies('');
-			setPlantedDate(new Date());
-			setNotes('');
-			setStatus(PLANT_STATUS.PLANTED);
-			onOpenChange(false);
-		}
-	};
-
-	const handleOpenChange = (newOpen: boolean) => {
-		if (!newOpen) {
-			// Reset form
-			setSelectedGrowingUnitId(initialGrowingUnitId || '');
-			setName('');
-			setSpecies('');
-			setPlantedDate(new Date());
-			setNotes('');
-			setStatus(PLANT_STATUS.PLANTED);
-			setFormErrors({});
-		}
-		onOpenChange(newOpen);
-	};
+	const {
+		selectedGrowingUnitId,
+		name,
+		species,
+		plantedDate,
+		notes,
+		status,
+		formErrors,
+		setSelectedGrowingUnitId,
+		setName,
+		setSpecies,
+		setPlantedDate,
+		setNotes,
+		setStatus,
+		handleSubmit,
+		handleOpenChange,
+	} = usePlantCreateForm({
+		initialGrowingUnitId,
+		onSubmit,
+		onOpenChange,
+		error,
+		translations: (key: string) => t(key),
+	});
 
 	return (
 		<Dialog open={open} onOpenChange={handleOpenChange}>

--- a/apps/web/features/plants/hooks/use-plant-create-form/use-plant-create-form.test.ts
+++ b/apps/web/features/plants/hooks/use-plant-create-form/use-plant-create-form.test.ts
@@ -1,0 +1,366 @@
+import { renderHook, act } from '@testing-library/react';
+import { usePlantCreateForm } from './use-plant-create-form';
+import { PLANT_STATUS } from '@/features/plants/constants/plant-status';
+
+describe('usePlantCreateForm', () => {
+	const mockOnSubmit = jest.fn();
+	const mockOnOpenChange = jest.fn();
+	const mockTranslations = (key: string) => key;
+
+	const defaultProps = {
+		onSubmit: mockOnSubmit,
+		onOpenChange: mockOnOpenChange,
+		error: null,
+		translations: mockTranslations,
+	};
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	describe('Initialization', () => {
+		it('should initialize with default values', () => {
+			const { result } = renderHook(() => usePlantCreateForm(defaultProps));
+
+			expect(result.current.selectedGrowingUnitId).toBe('');
+			expect(result.current.name).toBe('');
+			expect(result.current.species).toBe('');
+			expect(result.current.plantedDate).toBeInstanceOf(Date);
+			expect(result.current.notes).toBe('');
+			expect(result.current.status).toBe(PLANT_STATUS.PLANTED);
+			expect(result.current.formErrors).toEqual({});
+		});
+
+		it('should initialize with provided initialGrowingUnitId', () => {
+			const { result } = renderHook(() =>
+				usePlantCreateForm({
+					...defaultProps,
+					initialGrowingUnitId: 'unit-123',
+				}),
+			);
+
+			expect(result.current.selectedGrowingUnitId).toBe('unit-123');
+		});
+	});
+
+	describe('State Setters', () => {
+		it('should update selectedGrowingUnitId', () => {
+			const { result } = renderHook(() => usePlantCreateForm(defaultProps));
+
+			act(() => {
+				result.current.setSelectedGrowingUnitId('new-unit-id');
+			});
+
+			expect(result.current.selectedGrowingUnitId).toBe('new-unit-id');
+		});
+
+		it('should update name', () => {
+			const { result } = renderHook(() => usePlantCreateForm(defaultProps));
+
+			act(() => {
+				result.current.setName('Tomato Plant');
+			});
+
+			expect(result.current.name).toBe('Tomato Plant');
+		});
+
+		it('should update species', () => {
+			const { result } = renderHook(() => usePlantCreateForm(defaultProps));
+
+			act(() => {
+				result.current.setSpecies('Solanum lycopersicum');
+			});
+
+			expect(result.current.species).toBe('Solanum lycopersicum');
+		});
+
+		it('should update plantedDate', () => {
+			const { result } = renderHook(() => usePlantCreateForm(defaultProps));
+			const newDate = new Date('2024-01-15');
+
+			act(() => {
+				result.current.setPlantedDate(newDate);
+			});
+
+			expect(result.current.plantedDate).toEqual(newDate);
+		});
+
+		it('should update notes', () => {
+			const { result } = renderHook(() => usePlantCreateForm(defaultProps));
+
+			act(() => {
+				result.current.setNotes('This is a test note');
+			});
+
+			expect(result.current.notes).toBe('This is a test note');
+		});
+
+		it('should update status', () => {
+			const { result } = renderHook(() => usePlantCreateForm(defaultProps));
+
+			act(() => {
+				result.current.setStatus(PLANT_STATUS.GROWING);
+			});
+
+			expect(result.current.status).toBe(PLANT_STATUS.GROWING);
+		});
+	});
+
+	describe('handleSubmit', () => {
+		it('should validate and submit valid form data', async () => {
+			const { result } = renderHook(() => usePlantCreateForm(defaultProps));
+
+			// Set valid form data
+			act(() => {
+				result.current.setName('Test Plant');
+				result.current.setSpecies('Test Species');
+				result.current.setSelectedGrowingUnitId('unit-123');
+			});
+
+			const mockEvent = {
+				preventDefault: jest.fn(),
+			} as unknown as React.FormEvent<HTMLFormElement>;
+
+			await act(async () => {
+				await result.current.handleSubmit(mockEvent);
+			});
+
+			expect(mockEvent.preventDefault).toHaveBeenCalled();
+			expect(mockOnSubmit).toHaveBeenCalledWith(
+				expect.objectContaining({
+					name: 'Test Plant',
+					species: 'Test Species',
+					growingUnitId: 'unit-123',
+				}),
+			);
+		});
+
+		it('should set form errors when validation fails', async () => {
+			const { result } = renderHook(() => usePlantCreateForm(defaultProps));
+
+			// Submit without required fields
+			const mockEvent = {
+				preventDefault: jest.fn(),
+			} as unknown as React.FormEvent<HTMLFormElement>;
+
+			await act(async () => {
+				await result.current.handleSubmit(mockEvent);
+			});
+
+			expect(result.current.formErrors).not.toEqual({});
+			expect(mockOnSubmit).not.toHaveBeenCalled();
+		});
+
+		it('should use initialGrowingUnitId when selectedGrowingUnitId is empty', async () => {
+			const { result } = renderHook(() =>
+				usePlantCreateForm({
+					...defaultProps,
+					initialGrowingUnitId: 'initial-unit',
+				}),
+			);
+
+			act(() => {
+				result.current.setName('Test Plant');
+				result.current.setSpecies('Test Species');
+			});
+
+			const mockEvent = {
+				preventDefault: jest.fn(),
+			} as unknown as React.FormEvent<HTMLFormElement>;
+
+			await act(async () => {
+				await result.current.handleSubmit(mockEvent);
+			});
+
+			expect(mockOnSubmit).toHaveBeenCalledWith(
+				expect.objectContaining({
+					growingUnitId: 'initial-unit',
+				}),
+			);
+		});
+
+		it('should reset form and close dialog after successful submission', async () => {
+			const { result } = renderHook(() => usePlantCreateForm(defaultProps));
+
+			act(() => {
+				result.current.setName('Test Plant');
+				result.current.setSpecies('Test Species');
+				result.current.setSelectedGrowingUnitId('unit-123');
+				result.current.setNotes('Test notes');
+			});
+
+			const mockEvent = {
+				preventDefault: jest.fn(),
+			} as unknown as React.FormEvent<HTMLFormElement>;
+
+			await act(async () => {
+				await result.current.handleSubmit(mockEvent);
+			});
+
+			expect(result.current.name).toBe('');
+			expect(result.current.species).toBe('');
+			expect(result.current.notes).toBe('');
+			expect(mockOnOpenChange).toHaveBeenCalledWith(false);
+		});
+
+		it('should not reset form when submission fails', async () => {
+			const errorProps = {
+				...defaultProps,
+				error: new Error('Submission failed'),
+			};
+			const { result } = renderHook(() => usePlantCreateForm(errorProps));
+
+			act(() => {
+				result.current.setName('Test Plant');
+				result.current.setSpecies('Test Species');
+				result.current.setSelectedGrowingUnitId('unit-123');
+			});
+
+			const mockEvent = {
+				preventDefault: jest.fn(),
+			} as unknown as React.FormEvent<HTMLFormElement>;
+
+			await act(async () => {
+				await result.current.handleSubmit(mockEvent);
+			});
+
+			// Form should not be reset when there's an error
+			expect(result.current.name).toBe('Test Plant');
+			expect(mockOnOpenChange).not.toHaveBeenCalledWith(false);
+		});
+
+		it('should clear form errors before submission', async () => {
+			const { result } = renderHook(() => usePlantCreateForm(defaultProps));
+
+			// Set some form errors manually
+			act(() => {
+				result.current.setName('Test Plant');
+				result.current.setSpecies('Test Species');
+				result.current.setSelectedGrowingUnitId('unit-123');
+			});
+
+			// First submit to set errors
+			const mockEvent = {
+				preventDefault: jest.fn(),
+			} as unknown as React.FormEvent<HTMLFormElement>;
+
+			await act(async () => {
+				await result.current.handleSubmit(mockEvent);
+			});
+
+			expect(result.current.formErrors).toEqual({});
+		});
+	});
+
+	describe('handleOpenChange', () => {
+		it('should reset form when closing dialog', () => {
+			const { result } = renderHook(() => usePlantCreateForm(defaultProps));
+
+			// Set some form data
+			act(() => {
+				result.current.setName('Test Plant');
+				result.current.setSpecies('Test Species');
+				result.current.setNotes('Test notes');
+			});
+
+			// Close dialog
+			act(() => {
+				result.current.handleOpenChange(false);
+			});
+
+			expect(result.current.name).toBe('');
+			expect(result.current.species).toBe('');
+			expect(result.current.notes).toBe('');
+			expect(result.current.formErrors).toEqual({});
+			expect(mockOnOpenChange).toHaveBeenCalledWith(false);
+		});
+
+		it('should not reset form when opening dialog', () => {
+			const { result } = renderHook(() => usePlantCreateForm(defaultProps));
+
+			// Set some form data
+			act(() => {
+				result.current.setName('Test Plant');
+				result.current.setSpecies('Test Species');
+			});
+
+			// Open dialog
+			act(() => {
+				result.current.handleOpenChange(true);
+			});
+
+			expect(result.current.name).toBe('Test Plant');
+			expect(result.current.species).toBe('Test Species');
+			expect(mockOnOpenChange).toHaveBeenCalledWith(true);
+		});
+
+		it('should reset to initialGrowingUnitId when provided', () => {
+			const { result } = renderHook(() =>
+				usePlantCreateForm({
+					...defaultProps,
+					initialGrowingUnitId: 'initial-unit',
+				}),
+			);
+
+			// Change growing unit
+			act(() => {
+				result.current.setSelectedGrowingUnitId('different-unit');
+			});
+
+			// Close dialog
+			act(() => {
+				result.current.handleOpenChange(false);
+			});
+
+			expect(result.current.selectedGrowingUnitId).toBe('initial-unit');
+		});
+	});
+
+	describe('Form Validation Integration', () => {
+		it('should handle optional notes field correctly', async () => {
+			const { result } = renderHook(() => usePlantCreateForm(defaultProps));
+
+			act(() => {
+				result.current.setName('Test Plant');
+				result.current.setSpecies('Test Species');
+				result.current.setSelectedGrowingUnitId('unit-123');
+				// Don't set notes (optional)
+			});
+
+			const mockEvent = {
+				preventDefault: jest.fn(),
+			} as unknown as React.FormEvent<HTMLFormElement>;
+
+			await act(async () => {
+				await result.current.handleSubmit(mockEvent);
+			});
+
+			expect(mockOnSubmit).toHaveBeenCalled();
+		});
+
+		it('should validate status field', async () => {
+			const { result } = renderHook(() => usePlantCreateForm(defaultProps));
+
+			act(() => {
+				result.current.setName('Test Plant');
+				result.current.setSpecies('Test Species');
+				result.current.setSelectedGrowingUnitId('unit-123');
+				result.current.setStatus(PLANT_STATUS.HARVESTED);
+			});
+
+			const mockEvent = {
+				preventDefault: jest.fn(),
+			} as unknown as React.FormEvent<HTMLFormElement>;
+
+			await act(async () => {
+				await result.current.handleSubmit(mockEvent);
+			});
+
+			expect(mockOnSubmit).toHaveBeenCalledWith(
+				expect.objectContaining({
+					status: PLANT_STATUS.HARVESTED,
+				}),
+			);
+		});
+	});
+});

--- a/apps/web/features/plants/hooks/use-plant-create-form/use-plant-create-form.ts
+++ b/apps/web/features/plants/hooks/use-plant-create-form/use-plant-create-form.ts
@@ -1,0 +1,151 @@
+'use client';
+
+import { PLANT_STATUS } from '@/features/plants/constants/plant-status';
+import {
+	createPlantCreateSchema,
+	PlantCreateFormValues,
+} from 'features/plants/schemas/plant-create/plant-create.schema';
+import { useMemo, useState } from 'react';
+
+interface UsePlantCreateFormProps {
+	initialGrowingUnitId?: string;
+	onSubmit: (values: PlantCreateFormValues) => Promise<void>;
+	onOpenChange: (open: boolean) => void;
+	error: Error | null;
+	translations: (key: string) => string;
+}
+
+interface UsePlantCreateFormReturn {
+	// Form state
+	selectedGrowingUnitId: string;
+	name: string;
+	species: string;
+	plantedDate: Date;
+	notes: string;
+	status: PlantCreateFormValues['status'];
+	formErrors: Record<string, { message?: string }>;
+
+	// State setters
+	setSelectedGrowingUnitId: (value: string) => void;
+	setName: (value: string) => void;
+	setSpecies: (value: string) => void;
+	setPlantedDate: (value: Date) => void;
+	setNotes: (value: string) => void;
+	setStatus: (value: PlantCreateFormValues['status']) => void;
+
+	// Event handlers
+	handleSubmit: (e: React.FormEvent<HTMLFormElement>) => Promise<void>;
+	handleOpenChange: (newOpen: boolean) => void;
+}
+
+/**
+ * Custom hook for managing PlantCreateForm state and logic
+ * Encapsulates form state management, validation, and event handling
+ */
+export function usePlantCreateForm({
+	initialGrowingUnitId,
+	onSubmit,
+	onOpenChange,
+	error,
+	translations,
+}: UsePlantCreateFormProps): UsePlantCreateFormReturn {
+	// Create schema with translations
+	const createSchema = useMemo(
+		() => createPlantCreateSchema(translations),
+		[translations],
+	);
+
+	// Form state
+	const [selectedGrowingUnitId, setSelectedGrowingUnitId] = useState<string>(
+		initialGrowingUnitId || '',
+	);
+	const [name, setName] = useState('');
+	const [species, setSpecies] = useState('');
+	const [plantedDate, setPlantedDate] = useState<Date>(new Date());
+	const [notes, setNotes] = useState('');
+	const [status, setStatus] = useState<PlantCreateFormValues['status']>(
+		PLANT_STATUS.PLANTED,
+	);
+	const [formErrors, setFormErrors] = useState<
+		Record<string, { message?: string }>
+	>({});
+
+	// Reset form to initial state
+	const resetForm = () => {
+		setSelectedGrowingUnitId(initialGrowingUnitId || '');
+		setName('');
+		setSpecies('');
+		setPlantedDate(new Date());
+		setNotes('');
+		setStatus(PLANT_STATUS.PLANTED);
+		setFormErrors({});
+	};
+
+	// Handle form submission
+	const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+		e.preventDefault();
+
+		// Use selected growing unit ID or the provided one
+		const finalGrowingUnitId =
+			selectedGrowingUnitId || initialGrowingUnitId || '';
+
+		// Validate form
+		const result = createSchema.safeParse({
+			name,
+			species,
+			plantedDate,
+			notes: notes || undefined,
+			status,
+			growingUnitId: finalGrowingUnitId,
+		});
+
+		if (!result.success) {
+			const errors: Record<string, { message?: string }> = {};
+			result.error.issues.forEach((err) => {
+				if (err.path[0]) {
+					errors[err.path[0] as string] = { message: err.message };
+				}
+			});
+			setFormErrors(errors);
+			return;
+		}
+
+		setFormErrors({});
+		await onSubmit(result.data);
+		if (!error) {
+			resetForm();
+			onOpenChange(false);
+		}
+	};
+
+	// Handle dialog open/close
+	const handleOpenChange = (newOpen: boolean) => {
+		if (!newOpen) {
+			resetForm();
+		}
+		onOpenChange(newOpen);
+	};
+
+	return {
+		// Form state
+		selectedGrowingUnitId,
+		name,
+		species,
+		plantedDate,
+		notes,
+		status,
+		formErrors,
+
+		// State setters
+		setSelectedGrowingUnitId,
+		setName,
+		setSpecies,
+		setPlantedDate,
+		setStatus,
+		setNotes,
+
+		// Event handlers
+		handleSubmit,
+		handleOpenChange,
+	};
+}


### PR DESCRIPTION
- Created usePlantCreateForm custom hook to encapsulate all form state management, validation, and event handling
- Refactored PlantCreateForm component to be purely presentational (reduced from 306 to 250 lines)
- Added comprehensive unit tests for the hook with >80% coverage scenarios
- Improved separation of concerns following SRP

Fixes #92