### PR TITLE
refactor: Move inline transformations to usePlantsPage hook

### DIFF
--- a/apps/web/features/plants/components/pages/plants-page.tsx
+++ b/apps/web/features/plants/components/pages/plants-page.tsx
@@ -50,7 +50,7 @@ export function PlantsPage() {
 		handleDelete,
 		handlePageChange,
 		hasAnyPlants,
-		growingUnits,
+		transformedGrowingUnits,
 		isCreating,
 		createError,
 	} = usePlantsPage();
@@ -174,12 +174,7 @@ export function PlantsPage() {
 				onSubmit={handleCreateSubmit}
 				isLoading={isCreating}
 				error={createError}
-				growingUnits={
-					growingUnits?.items.map((unit: { id: string; name: string }) => ({
-						id: unit.id,
-						name: unit.name,
-					})) || []
-				}
+				growingUnits={transformedGrowingUnits}
 			/>
 		</div>
 	);

--- a/apps/web/features/plants/hooks/use-plants-page/use-plants-page.ts
+++ b/apps/web/features/plants/hooks/use-plants-page/use-plants-page.ts
@@ -165,6 +165,14 @@ export function usePlantsPage() {
     return plants && plants.total > 0;
   }, [plants]);
 
+  // Transform growing units for the create form
+  const transformedGrowingUnits = useMemo(() => {
+    return growingUnits?.items.map((unit: { id: string; name: string }) => ({
+      id: unit.id,
+      name: unit.name,
+    })) || [];
+  }, [growingUnits]);
+
   return {
     // State
     searchQuery,
@@ -179,6 +187,7 @@ export function usePlantsPage() {
 
     // Data
     growingUnits,
+    transformedGrowingUnits,
     allFilteredPlants,
     paginatedPlants,
     totalPages,


### PR DESCRIPTION
Move growingUnits.map() transformation from PlantsPage component to usePlantsPage hook for consistency and better separation of concerns. All transformations are now centralized in hooks, keeping components focused on JSX rendering.

- Add transformedGrowingUnits to usePlantsPage hook
- Update PlantsPage to use transformedGrowingUnits from hook
- LocationsPage and GrowingUnitsPage already follow the correct pattern

Resolves #108