### PR TITLE
refactor: extract data transformation from UserProfilePage

### DIFF
--- a/apps/web/features/users/api/types.test.ts
+++ b/apps/web/features/users/api/types.test.ts
@@ -1,0 +1,196 @@
+import type { AuthUserProfileResponse } from 'features/auth/api/types';
+import { transformAuthProfileToUser } from './types';
+
+describe('transformAuthProfileToUser', () => {
+	it('should transform AuthUserProfileResponse to UserResponse with all fields', () => {
+		const authProfile: AuthUserProfileResponse = {
+			userId: '123',
+			authId: 'auth-123',
+			userName: 'testuser',
+			name: 'John',
+			lastName: 'Doe',
+			bio: 'Test bio',
+			avatarUrl: 'https://example.com/avatar.jpg',
+			role: 'USER',
+			status: 'ACTIVE',
+			createdAt: new Date('2024-01-01'),
+			updatedAt: new Date('2024-01-02'),
+			email: 'test@example.com',
+			phoneNumber: '+1234567890',
+			emailVerified: true,
+			twoFactorEnabled: false,
+			lastLoginAt: new Date('2024-01-03'),
+		};
+
+		const result = transformAuthProfileToUser(authProfile);
+
+		expect(result).toEqual({
+			userId: '123',
+			userName: 'testuser',
+			name: 'John',
+			lastName: 'Doe',
+			bio: 'Test bio',
+			avatarUrl: 'https://example.com/avatar.jpg',
+			role: 'USER',
+			status: 'ACTIVE',
+			createdAt: new Date('2024-01-01'),
+			updatedAt: new Date('2024-01-02'),
+			email: 'test@example.com',
+			phoneNumber: '+1234567890',
+			emailVerified: true,
+			twoFactorEnabled: false,
+			lastLogin: new Date('2024-01-03'),
+		});
+	});
+
+	it('should handle null and undefined values correctly', () => {
+		const authProfile: AuthUserProfileResponse = {
+			userId: '123',
+			authId: 'auth-123',
+			userName: null,
+			name: undefined,
+			lastName: null,
+			bio: null,
+			avatarUrl: null,
+			role: 'ADMIN',
+			status: 'INACTIVE',
+			createdAt: undefined,
+			updatedAt: null,
+			email: null,
+			phoneNumber: null,
+			emailVerified: undefined,
+			twoFactorEnabled: null,
+			lastLoginAt: null,
+		};
+
+		const result = transformAuthProfileToUser(authProfile);
+
+		expect(result).toEqual({
+			userId: '123',
+			userName: null,
+			name: null,
+			lastName: null,
+			bio: null,
+			avatarUrl: null,
+			role: 'ADMIN',
+			status: 'INACTIVE',
+			createdAt: expect.any(Date),
+			updatedAt: expect.any(Date),
+			email: null,
+			phoneNumber: null,
+			emailVerified: false,
+			twoFactorEnabled: false,
+			lastLogin: null,
+		});
+	});
+
+	it('should use default values for missing createdAt and updatedAt', () => {
+		const authProfile: AuthUserProfileResponse = {
+			userId: '123',
+			authId: 'auth-123',
+			userName: 'testuser',
+			name: 'John',
+			lastName: 'Doe',
+			bio: null,
+			avatarUrl: null,
+			role: 'USER',
+			status: 'ACTIVE',
+			createdAt: undefined,
+			updatedAt: undefined,
+			email: 'test@example.com',
+			phoneNumber: null,
+			emailVerified: true,
+			twoFactorEnabled: false,
+			lastLoginAt: null,
+		};
+
+		const result = transformAuthProfileToUser(authProfile);
+
+		expect(result.createdAt).toBeInstanceOf(Date);
+		expect(result.updatedAt).toBeInstanceOf(Date);
+	});
+
+	it('should correctly map lastLoginAt to lastLogin', () => {
+		const lastLoginDate = new Date('2024-01-15T10:30:00Z');
+		const authProfile: AuthUserProfileResponse = {
+			userId: '123',
+			authId: 'auth-123',
+			userName: 'testuser',
+			name: 'John',
+			lastName: 'Doe',
+			bio: null,
+			avatarUrl: null,
+			role: 'USER',
+			status: 'ACTIVE',
+			createdAt: new Date(),
+			updatedAt: new Date(),
+			email: 'test@example.com',
+			phoneNumber: null,
+			emailVerified: true,
+			twoFactorEnabled: false,
+			lastLoginAt: lastLoginDate,
+		};
+
+		const result = transformAuthProfileToUser(authProfile);
+
+		expect(result.lastLogin).toEqual(lastLoginDate);
+	});
+
+	it('should handle all user roles correctly', () => {
+		const roles = ['USER', 'ADMIN', 'MODERATOR'] as const;
+
+		roles.forEach((role) => {
+			const authProfile: AuthUserProfileResponse = {
+				userId: '123',
+				authId: 'auth-123',
+				userName: 'testuser',
+				name: 'John',
+				lastName: 'Doe',
+				bio: null,
+				avatarUrl: null,
+				role,
+				status: 'ACTIVE',
+				createdAt: new Date(),
+				updatedAt: new Date(),
+				email: 'test@example.com',
+				phoneNumber: null,
+				emailVerified: true,
+				twoFactorEnabled: false,
+				lastLoginAt: null,
+			};
+
+			const result = transformAuthProfileToUser(authProfile);
+
+			expect(result.role).toBe(role);
+		});
+	});
+
+	it('should handle all user statuses correctly', () => {
+		const statuses = ['ACTIVE', 'INACTIVE', 'SUSPENDED', 'DELETED'] as const;
+
+		statuses.forEach((status) => {
+			const authProfile: AuthUserProfileResponse = {
+				userId: '123',
+				authId: 'auth-123',
+				userName: 'testuser',
+				name: 'John',
+				lastName: 'Doe',
+				bio: null,
+				avatarUrl: null,
+				role: 'USER',
+				status,
+				createdAt: new Date(),
+				updatedAt: new Date(),
+				email: 'test@example.com',
+				phoneNumber: null,
+				emailVerified: true,
+				twoFactorEnabled: false,
+				lastLoginAt: null,
+			};
+
+			const result = transformAuthProfileToUser(authProfile);
+
+			expect(result.status).toBe(status);
+		});
+	});
+});

--- a/apps/web/features/users/api/types.ts
+++ b/apps/web/features/users/api/types.ts
@@ -94,3 +94,29 @@ export function transformUserResponse(
 		updatedAt: new Date(apiUser.updatedAt),
 	};
 }
+
+/**
+ * Transform AuthUserProfileResponse to UserResponse format
+ * Used to convert auth profile data to user response format for forms and UI
+ */
+export function transformAuthProfileToUser(
+	profile: import('features/auth/api/types').AuthUserProfileResponse,
+): UserResponse {
+	return {
+		userId: profile.userId,
+		userName: profile.userName || null,
+		name: profile.name || null,
+		lastName: profile.lastName || null,
+		bio: profile.bio || null,
+		avatarUrl: profile.avatarUrl || null,
+		role: profile.role as UserRole,
+		status: profile.status as UserStatus,
+		createdAt: profile.createdAt ?? new Date(),
+		updatedAt: profile.updatedAt ?? new Date(),
+		email: profile.email ?? null,
+		phoneNumber: profile.phoneNumber || null,
+		emailVerified: profile.emailVerified ?? false,
+		twoFactorEnabled: profile.twoFactorEnabled ?? false,
+		lastLogin: profile.lastLoginAt ?? null,
+	};
+}

--- a/apps/web/features/users/components/pages/user-profile-page.tsx
+++ b/apps/web/features/users/components/pages/user-profile-page.tsx
@@ -1,6 +1,9 @@
 'use client';
 
-import { UserResponse, UserRole, UserStatus } from '@/features/users/api/types';
+import {
+	UserResponse,
+	transformAuthProfileToUser,
+} from '@/features/users/api/types';
 import {
 	Card,
 	CardContent,
@@ -72,23 +75,7 @@ export function UserProfilePage() {
 	}
 
 	// Convert AuthUserProfileResponse to UserResponse format for the form
-	const user: UserResponse = {
-		userId: profile.userId,
-		userName: profile.userName || null,
-		name: profile.name || null,
-		lastName: profile.lastName || null,
-		bio: profile.bio || null,
-		avatarUrl: profile.avatarUrl || null,
-		role: profile.role as UserRole,
-		status: profile.status as UserStatus,
-		createdAt: profile.createdAt ?? new Date(),
-		updatedAt: profile.updatedAt ?? new Date(),
-		email: profile.email ?? null,
-		phoneNumber: profile.phoneNumber || null,
-		emailVerified: profile.emailVerified ?? false,
-		twoFactorEnabled: profile.twoFactorEnabled ?? false,
-		lastLogin: profile.lastLoginAt ?? null,
-	};
+	const user: UserResponse = transformAuthProfileToUser(profile);
 
 	return (
 		<div className="mx-auto space-y-6">


### PR DESCRIPTION
- Created transformAuthProfileToUser utility function in users/api/types.ts
- Refactored UserProfilePage to use the new transformation utility
- Added comprehensive unit tests for the transformation logic
- Reduced inline transformation from 17 lines to 1 line
- Improved code maintainability and testability

Resolves #107