### PR TITLE
refactor(web): Organize translations by feature with separate locale files

### DIFF
--- a/apps/web/features/auth/components/molecules/auth-confirm-password-field/auth-confirm-password-field.tsx
+++ b/apps/web/features/auth/components/molecules/auth-confirm-password-field/auth-confirm-password-field.tsx
@@ -28,11 +28,11 @@ export function AuthConfirmPasswordField({
 
 	return (
 		<FormItem>
-			<FormLabel>{t('pages.auth.fields.confirmPassword.label')}</FormLabel>
+			<FormLabel>{t('features.auth.fields.confirmPassword.label')}</FormLabel>
 			<FormControl>
 				<Input
 					type="password"
-					placeholder={t('pages.auth.fields.confirmPassword.placeholder')}
+					placeholder={t('features.auth.fields.confirmPassword.placeholder')}
 					disabled={disabled}
 					value={value}
 					onChange={(e) => {

--- a/apps/web/features/auth/components/molecules/auth-email-field/auth-email-field.tsx
+++ b/apps/web/features/auth/components/molecules/auth-email-field/auth-email-field.tsx
@@ -28,11 +28,11 @@ export function AuthEmailField({
 
 	return (
 		<FormItem>
-			<FormLabel>{t('pages.auth.fields.email.label')}</FormLabel>
+			<FormLabel>{t('features.auth.fields.email.label')}</FormLabel>
 			<FormControl>
 				<Input
 					type="email"
-					placeholder={t('pages.auth.fields.email.placeholder')}
+					placeholder={t('features.auth.fields.email.placeholder')}
 					disabled={disabled}
 					value={value}
 					onChange={(e) => {

--- a/apps/web/features/auth/components/molecules/auth-password-field/auth-password-field.tsx
+++ b/apps/web/features/auth/components/molecules/auth-password-field/auth-password-field.tsx
@@ -30,12 +30,12 @@ export function AuthPasswordField({
 
 	return (
 		<FormItem>
-			<FormLabel>{t('pages.auth.fields.password.label')}</FormLabel>
+			<FormLabel>{t('features.auth.fields.password.label')}</FormLabel>
 			<FormControl>
 				<Input
 					type="password"
 					placeholder={t(
-						`pages.auth.fields.password.placeholder.${placeholder}`,
+						`features.auth.fields.password.placeholder.${placeholder}`,
 					)}
 					disabled={disabled}
 					value={value}

--- a/apps/web/features/auth/components/molecules/auth-submit-button/auth-submit-button.tsx
+++ b/apps/web/features/auth/components/molecules/auth-submit-button/auth-submit-button.tsx
@@ -22,10 +22,10 @@ export function AuthSubmitButton({
 			{isLoading ? (
 				<>
 					<Loader2 className="mr-2 h-4 w-4 animate-spin" />
-					{t(`pages.auth.actions.loading.${mode}`)}
+					{t(`features.auth.actions.loading.${mode}`)}
 				</>
 			) : (
-				t(`pages.auth.actions.${mode}`)
+				t(`features.auth.actions.${mode}`)
 			)}
 		</Button>
 	);

--- a/apps/web/features/auth/components/organisms/auth-card/auth-card.tsx
+++ b/apps/web/features/auth/components/organisms/auth-card/auth-card.tsx
@@ -26,10 +26,10 @@ export function AuthCard({ children, isLoading, error, mode }: AuthCardProps) {
 		<Card className="w-full max-w-md">
 			<CardHeader className="space-y-1">
 				<CardTitle className="text-2xl font-bold text-center">
-					{t(`pages.auth.title.${mode}`)}
+					{t(`features.auth.title.${mode}`)}
 				</CardTitle>
 				<CardDescription className="text-center">
-					{t(`pages.auth.description.${mode}`)}
+					{t(`features.auth.description.${mode}`)}
 				</CardDescription>
 			</CardHeader>
 			<CardContent>

--- a/apps/web/features/auth/components/pages/auth-page.tsx
+++ b/apps/web/features/auth/components/pages/auth-page.tsx
@@ -56,7 +56,7 @@ const AuthPage = () => {
 					{isLoginMode ? (
 						<>
 							<span className="text-muted-foreground">
-								{t('pages.auth.messages.switchToSignup')}{' '}
+								{t('features.auth.messages.switchToSignup')}{' '}
 							</span>
 							<Button
 								variant="link"
@@ -64,13 +64,13 @@ const AuthPage = () => {
 								onClick={() => setIsLoginMode(false)}
 								disabled={isLoading}
 							>
-								{t('pages.auth.actions.switchToSignup')}
+								{t('features.auth.actions.switchToSignup')}
 							</Button>
 						</>
 					) : (
 						<>
 							<span className="text-muted-foreground">
-								{t('pages.auth.messages.switchToLogin')}{' '}
+								{t('features.auth.messages.switchToLogin')}{' '}
 							</span>
 							<Button
 								variant="link"
@@ -78,7 +78,7 @@ const AuthPage = () => {
 								onClick={() => setIsLoginMode(true)}
 								disabled={isLoading}
 							>
-								{t('pages.auth.actions.switchToLogin')}
+								{t('features.auth.actions.switchToLogin')}
 							</Button>
 						</>
 					)}

--- a/apps/web/features/auth/locales/en.json
+++ b/apps/web/features/auth/locales/en.json
@@ -1,0 +1,56 @@
+{
+  "title": {
+    "login": "Welcome back",
+    "signup": "Create an account"
+  },
+  "description": {
+    "login": "Enter your email and password to sign in",
+    "signup": "Enter your information to create a new account"
+  },
+  "fields": {
+    "email": {
+      "label": "Email",
+      "placeholder": "name@example.com"
+    },
+    "password": {
+      "label": "Password",
+      "placeholder": {
+        "login": "Enter your password",
+        "signup": "At least 8 characters"
+      }
+    },
+    "confirmPassword": {
+      "label": "Confirm Password",
+      "placeholder": "Confirm your password"
+    }
+  },
+  "actions": {
+    "login": "Sign in",
+    "signup": "Create account",
+    "switchToSignup": "Sign up",
+    "switchToLogin": "Sign in",
+    "loading": {
+      "login": "Signing in...",
+      "signup": "Creating account..."
+    }
+  },
+  "messages": {
+    "switchToSignup": "Don't have an account?",
+    "switchToLogin": "Already have an account?",
+    "error": "An error occurred. Please try again."
+  },
+  "validation": {
+    "email": {
+      "required": "Email is required",
+      "invalid": "Invalid email format"
+    },
+    "password": {
+      "required": "Password is required",
+      "minLength": "Password must be at least 8 characters"
+    },
+    "confirmPassword": {
+      "required": "Please confirm your password",
+      "mismatch": "Passwords don't match"
+    }
+  }
+}

--- a/apps/web/features/auth/locales/es.json
+++ b/apps/web/features/auth/locales/es.json
@@ -1,0 +1,56 @@
+{
+  "title": {
+    "login": "Bienvenido de nuevo",
+    "signup": "Crear una cuenta"
+  },
+  "description": {
+    "login": "Ingresa tu email y contraseña para iniciar sesión",
+    "signup": "Ingresa tu información para crear una nueva cuenta"
+  },
+  "fields": {
+    "email": {
+      "label": "Email",
+      "placeholder": "nombre@ejemplo.com"
+    },
+    "password": {
+      "label": "Contraseña",
+      "placeholder": {
+        "login": "Ingresa tu contraseña",
+        "signup": "Al menos 8 caracteres"
+      }
+    },
+    "confirmPassword": {
+      "label": "Confirmar contraseña",
+      "placeholder": "Confirma tu contraseña"
+    }
+  },
+  "actions": {
+    "login": "Iniciar sesión",
+    "signup": "Crear cuenta",
+    "switchToSignup": "Registrarse",
+    "switchToLogin": "Iniciar sesión",
+    "loading": {
+      "login": "Iniciando sesión...",
+      "signup": "Creando cuenta..."
+    }
+  },
+  "messages": {
+    "switchToSignup": "¿No tienes una cuenta?",
+    "switchToLogin": "¿Ya tienes una cuenta?",
+    "error": "Ocurrió un error. Por favor intenta de nuevo."
+  },
+  "validation": {
+    "email": {
+      "required": "El email es requerido",
+      "invalid": "Formato de email inválido"
+    },
+    "password": {
+      "required": "La contraseña es requerida",
+      "minLength": "La contraseña debe tener al menos 8 caracteres"
+    },
+    "confirmPassword": {
+      "required": "Por favor confirma tu contraseña",
+      "mismatch": "Las contraseñas no coinciden"
+    }
+  }
+}

--- a/apps/web/features/auth/schemas/auth-login-by-email/auth-login-by-email.schema.ts
+++ b/apps/web/features/auth/schemas/auth-login-by-email/auth-login-by-email.schema.ts
@@ -13,12 +13,12 @@ export function createAuthLoginByEmailSchema(
 	return z.object({
 		email: z
 			.string()
-			.min(1, translations("pages.auth.validation.email.required"))
-			.email(translations("pages.auth.validation.email.invalid")),
+			.min(1, translations("features.auth.validation.email.required"))
+			.email(translations("features.auth.validation.email.invalid")),
 		password: z
 			.string()
-			.min(1, translations("pages.auth.validation.password.required"))
-			.min(8, translations("pages.auth.validation.password.minLength")),
+			.min(1, translations("features.auth.validation.password.required"))
+			.min(8, translations("features.auth.validation.password.minLength")),
 	});
 }
 

--- a/apps/web/features/auth/schemas/auth-register-by-email/auth-register-by-email.schema.ts
+++ b/apps/web/features/auth/schemas/auth-register-by-email/auth-register-by-email.schema.ts
@@ -14,18 +14,18 @@ export function createAuthRegisterByEmailSchema(
 		.object({
 			email: z
 				.string()
-				.min(1, translations("pages.auth.validation.email.required"))
-				.email(translations("pages.auth.validation.email.invalid")),
+				.min(1, translations("features.auth.validation.email.required"))
+				.email(translations("features.auth.validation.email.invalid")),
 			password: z
 				.string()
-				.min(1, translations("pages.auth.validation.password.required"))
-				.min(8, translations("pages.auth.validation.password.minLength")),
+				.min(1, translations("features.auth.validation.password.required"))
+				.min(8, translations("features.auth.validation.password.minLength")),
 			confirmPassword: z
 				.string()
-				.min(1, translations("pages.auth.validation.confirmPassword.required")),
+				.min(1, translations("features.auth.validation.confirmPassword.required")),
 		})
 		.refine((data) => data.password === data.confirmPassword, {
-			message: translations("pages.auth.validation.confirmPassword.mismatch"),
+			message: translations("features.auth.validation.confirmPassword.mismatch"),
 			path: ["confirmPassword"],
 		});
 }

--- a/apps/web/features/dashboard/components/organisms/dashboard-stats-cards/dashboard-stats-cards.tsx
+++ b/apps/web/features/dashboard/components/organisms/dashboard-stats-cards/dashboard-stats-cards.tsx
@@ -35,7 +35,7 @@ export function DashboardStatsCards({
 	criticalAlerts,
 	isLoading = false,
 }: DashboardStatsCardsProps) {
-	const t = useTranslations('dashboard.stats');
+	const t = useTranslations('features.dashboard.stats');
 
 	if (isLoading) {
 		return (

--- a/apps/web/features/dashboard/components/organisms/growing-units-status-section/growing-units-status-section.tsx
+++ b/apps/web/features/dashboard/components/organisms/growing-units-status-section/growing-units-status-section.tsx
@@ -27,7 +27,7 @@ export function GrowingUnitsStatusSection({
 	growingUnits,
 	isLoading = false,
 }: GrowingUnitsStatusSectionProps) {
-	const t = useTranslations('dashboard.growingUnitsStatus');
+	const t = useTranslations('features.dashboard.growingUnitsStatus');
 	const { routes } = useAppRoutes();
 
 	if (isLoading) {

--- a/apps/web/features/dashboard/components/organisms/overview-capacity-section/overview-capacity-section.tsx
+++ b/apps/web/features/dashboard/components/organisms/overview-capacity-section/overview-capacity-section.tsx
@@ -25,7 +25,7 @@ export function OverviewCapacitySection({
 	overview,
 	isLoading = false,
 }: OverviewCapacitySectionProps) {
-	const t = useTranslations('dashboard.sections.capacity');
+	const t = useTranslations('features.dashboard.sections.capacity');
 
 	if (isLoading || !overview) {
 		return (

--- a/apps/web/features/dashboard/components/organisms/overview-growing-units-section/overview-growing-units-section.tsx
+++ b/apps/web/features/dashboard/components/organisms/overview-growing-units-section/overview-growing-units-section.tsx
@@ -30,7 +30,7 @@ export function OverviewGrowingUnitsSection({
 	overview,
 	isLoading = false,
 }: OverviewGrowingUnitsSectionProps) {
-	const t = useTranslations('dashboard.sections.growingUnits');
+	const t = useTranslations('features.dashboard.sections.growingUnits');
 
 	if (isLoading || !overview) {
 		return (

--- a/apps/web/features/dashboard/components/organisms/overview-plants-section/overview-plants-section.tsx
+++ b/apps/web/features/dashboard/components/organisms/overview-plants-section/overview-plants-section.tsx
@@ -33,7 +33,7 @@ export function OverviewPlantsSection({
 	overview,
 	isLoading = false,
 }: OverviewPlantsSectionProps) {
-	const t = useTranslations('dashboard.sections.plants');
+	const t = useTranslations('features.dashboard.sections.plants');
 
 	if (isLoading || !overview) {
 		return (

--- a/apps/web/features/dashboard/components/organisms/overview-stats-cards/overview-stats-cards.tsx
+++ b/apps/web/features/dashboard/components/organisms/overview-stats-cards/overview-stats-cards.tsx
@@ -29,8 +29,8 @@ export function OverviewStatsCards({
 	overview,
 	isLoading = false,
 }: OverviewStatsCardsProps) {
-	const t = useTranslations('dashboard.stats');
-	const tCommon = useTranslations('dashboard.common');
+	const t = useTranslations('features.dashboard.stats');
+	const tCommon = useTranslations('features.dashboard.common');
 
 	if (isLoading || !overview) {
 		return (

--- a/apps/web/features/dashboard/components/organisms/recent-alerts-section/recent-alerts-section.tsx
+++ b/apps/web/features/dashboard/components/organisms/recent-alerts-section/recent-alerts-section.tsx
@@ -31,7 +31,7 @@ export function RecentAlertsSection({
 	alerts,
 	isLoading = false,
 }: RecentAlertsSectionProps) {
-	const t = useTranslations('dashboard.recentAlerts');
+	const t = useTranslations('features.dashboard.recentAlerts');
 
 	if (isLoading) {
 		return (

--- a/apps/web/features/dashboard/components/organisms/today-tasks-section/today-tasks-section.tsx
+++ b/apps/web/features/dashboard/components/organisms/today-tasks-section/today-tasks-section.tsx
@@ -33,7 +33,7 @@ export function TodayTasksSection({
 	tasks,
 	isLoading = false,
 }: TodayTasksSectionProps) {
-	const t = useTranslations('dashboard.todayTasks');
+	const t = useTranslations('features.dashboard.todayTasks');
 
 	if (isLoading) {
 		return (

--- a/apps/web/features/dashboard/locales/en.json
+++ b/apps/web/features/dashboard/locales/en.json
@@ -1,0 +1,87 @@
+{
+  "page": {
+    "title": "Control Panel",
+    "description": "Welcome back, here's today's summary.",
+    "addPlantButton": "Add Plant"
+  },
+  "error": {
+    "loading": "Error loading dashboard: {message}"
+  },
+  "stats": {
+    "totalPlants": {
+      "title": "Total Plants"
+    },
+    "activeUnits": {
+      "title": "Active Units"
+    },
+    "readyForHarvest": {
+      "title": "Ready for Harvest"
+    },
+    "criticalAlerts": {
+      "title": "Critical Alerts"
+    },
+    "changeSuffix": "vs last month"
+  },
+  "sections": {
+    "plants": {
+      "title": "Plants Overview",
+      "totalPlants": "Total Plants",
+      "activePlants": "Active Plants",
+      "activePercentage": "{percentage}% active",
+      "statusBreakdown": "Status Breakdown",
+      "additionalMetrics": "Additional Metrics",
+      "planted": "Planted",
+      "growing": "Growing",
+      "harvested": "Harvested",
+      "dead": "Dead",
+      "archived": "Archived",
+      "withoutPlantedDate": "Without Planted Date",
+      "withNotes": "With Notes",
+      "recent7Days": "Recent (7 days)"
+    },
+    "capacity": {
+      "title": "Capacity Overview",
+      "averageOccupancy": "Average Occupancy",
+      "totalCapacity": "Total Capacity",
+      "used": "Used",
+      "available": "Available",
+      "atLimit": "At Limit (≥80%)",
+      "full": "Full (100%)"
+    },
+    "growingUnits": {
+      "title": "Growing Units Overview",
+      "totalGrowingUnits": "Total Growing Units",
+      "active": "Active",
+      "empty": "Empty",
+      "byType": "By Type",
+      "percentageOfTotal": "{percentage}% of total",
+      "avgPlantsPerUnit": "Avg Plants/Unit",
+      "min": "Min",
+      "max": "Max",
+      "pots": "Pots",
+      "gardenBeds": "Garden Beds",
+      "hangingBaskets": "Hanging Baskets",
+      "windowBoxes": "Window Boxes"
+    },
+    "growingUnitsStatus": {
+      "title": "Status of Cultivation Units",
+      "empty": "No growing units available"
+    },
+    "recentAlerts": {
+      "title": "Recent Alerts",
+      "empty": "No recent alerts"
+    },
+    "todayTasks": {
+      "title": "Today's Tasks",
+      "assignedTo": "Assigned to",
+      "empty": "No tasks scheduled for today"
+    }
+  },
+  "common": {
+    "retry": "Retry",
+    "active": "active",
+    "total": "total",
+    "growing": "growing",
+    "atLimit": "at limit"
+  }
+}

--- a/apps/web/features/dashboard/locales/es.json
+++ b/apps/web/features/dashboard/locales/es.json
@@ -1,0 +1,87 @@
+{
+  "page": {
+    "title": "Panel de Control",
+    "description": "Bienvenido de nuevo, aquí tienes el resumen de hoy.",
+    "addPlantButton": "Añadir Planta"
+  },
+  "error": {
+    "loading": "Error al cargar el dashboard: {message}"
+  },
+  "stats": {
+    "totalPlants": {
+      "title": "Total Plantas"
+    },
+    "activeUnits": {
+      "title": "Unidades Activas"
+    },
+    "readyForHarvest": {
+      "title": "Listas para Cosecha"
+    },
+    "criticalAlerts": {
+      "title": "Alertas Críticas"
+    },
+    "changeSuffix": "vs mes anterior"
+  },
+  "sections": {
+    "plants": {
+      "title": "Resumen de Plantas",
+      "totalPlants": "Total Plantas",
+      "activePlants": "Plantas Activas",
+      "activePercentage": "{percentage}% activas",
+      "statusBreakdown": "Desglose por Estado",
+      "additionalMetrics": "Métricas Adicionales",
+      "planted": "Plantadas",
+      "growing": "Creciendo",
+      "harvested": "Cosechadas",
+      "dead": "Muertas",
+      "archived": "Archivadas",
+      "withoutPlantedDate": "Sin Fecha de Plantación",
+      "withNotes": "Con Notas",
+      "recent7Days": "Recientes (7 días)"
+    },
+    "capacity": {
+      "title": "Resumen de Capacidad",
+      "averageOccupancy": "Ocupación Promedio",
+      "totalCapacity": "Capacidad Total",
+      "used": "Usada",
+      "available": "Disponible",
+      "atLimit": "En Límite (≥80%)",
+      "full": "Llena (100%)"
+    },
+    "growingUnits": {
+      "title": "Resumen de Unidades de Cultivo",
+      "totalGrowingUnits": "Total Unidades de Cultivo",
+      "active": "Activas",
+      "empty": "Vacías",
+      "byType": "Por Tipo",
+      "percentageOfTotal": "{percentage}% del total",
+      "avgPlantsPerUnit": "Prom. Plantas/Unidad",
+      "min": "Mín",
+      "max": "Máx",
+      "pots": "Macetas",
+      "gardenBeds": "Bancales",
+      "hangingBaskets": "Cestas Colgantes",
+      "windowBoxes": "Jardines de Ventana"
+    },
+    "growingUnitsStatus": {
+      "title": "Estado de Unidades de Cultivo",
+      "empty": "No hay unidades de cultivo disponibles"
+    },
+    "recentAlerts": {
+      "title": "Alertas Recientes",
+      "empty": "No hay alertas recientes"
+    },
+    "todayTasks": {
+      "title": "Tareas de Hoy",
+      "assignedTo": "Asignado a",
+      "empty": "No hay tareas programadas para hoy"
+    }
+  },
+  "common": {
+    "retry": "Reintentar",
+    "active": "activas",
+    "total": "total",
+    "growing": "creciendo",
+    "atLimit": "en límite"
+  }
+}

--- a/apps/web/features/growing-units/components/organisms/growing-unit-add-card/growing-unit-add-card.tsx
+++ b/apps/web/features/growing-units/components/organisms/growing-unit-add-card/growing-unit-add-card.tsx
@@ -19,10 +19,10 @@ export function GrowingUnitAddCard({ onClick }: GrowingUnitAddCardProps) {
 			<CardContent className="flex flex-col items-center justify-center min-h-[300px] p-6">
 				<PlusIcon className="h-12 w-12 text-muted-foreground mb-4" />
 				<h3 className="text-lg font-semibold mb-2">
-					{t('pages.growingUnits.list.actions.create.button')}
+					{t('features.growingUnits.list.actions.create.button')}
 				</h3>
 				<p className="text-sm text-muted-foreground text-center">
-					{t('pages.growingUnits.list.actions.create.description')}
+					{t('features.growingUnits.list.actions.create.description')}
 				</p>
 			</CardContent>
 		</Card>

--- a/apps/web/features/growing-units/components/organisms/growing-unit-card/growing-unit-card.tsx
+++ b/apps/web/features/growing-units/components/organisms/growing-unit-card/growing-unit-card.tsx
@@ -88,7 +88,7 @@ export function GrowingUnitCard({ growingUnit }: GrowingUnitCardProps) {
 									<span>
 										{plant.name ||
 											plant.species ||
-											t('pages.plants.detail.unnamed')}
+											t('features.plants.detail.unnamed')}
 									</span>
 								</div>
 							))}
@@ -101,7 +101,7 @@ export function GrowingUnitCard({ growingUnit }: GrowingUnitCardProps) {
 					</div>
 				) : (
 					<div className="text-sm text-muted-foreground">
-						{t('pages.growingUnits.list.noPlants')}
+						{t('features.growingUnits.list.noPlants')}
 					</div>
 				)}
 			</CardContent>

--- a/apps/web/features/growing-units/components/organisms/growing-unit-create-form/growing-unit-create-form.tsx
+++ b/apps/web/features/growing-units/components/organisms/growing-unit-create-form/growing-unit-create-form.tsx
@@ -79,10 +79,10 @@ export function GrowingUnitCreateForm({
 			<DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
 				<DialogHeader>
 					<DialogTitle>
-						{t('pages.growingUnits.list.actions.create.title')}
+						{t('features.growingUnits.list.actions.create.title')}
 					</DialogTitle>
 					<DialogDescription>
-						{t('pages.growingUnits.list.actions.create.description')}
+						{t('features.growingUnits.list.actions.create.description')}
 					</DialogDescription>
 				</DialogHeader>
 				<Form errors={formErrors}>
@@ -117,7 +117,7 @@ export function GrowingUnitCreateForm({
 							<FormControl>
 								<Input
 									placeholder={t(
-										'pages.growingUnits.detail.fields.name.placeholder',
+										'features.growingUnits.detail.fields.name.placeholder',
 									)}
 									disabled={isLoading}
 									value={name}
@@ -289,8 +289,8 @@ export function GrowingUnitCreateForm({
 							</Button>
 							<Button type="submit" disabled={isLoading}>
 								{isLoading
-									? t('pages.growingUnits.list.actions.create.loading')
-									: t('pages.growingUnits.list.actions.create.submit')}
+									? t('features.growingUnits.list.actions.create.loading')
+									: t('features.growingUnits.list.actions.create.submit')}
 							</Button>
 						</DialogFooter>
 					</form>

--- a/apps/web/features/growing-units/components/organisms/growing-unit-update-form/growing-unit-update-form.tsx
+++ b/apps/web/features/growing-units/components/organisms/growing-unit-update-form/growing-unit-update-form.tsx
@@ -85,10 +85,10 @@ export function GrowingUnitUpdateForm({
 			<DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
 				<DialogHeader>
 					<DialogTitle>
-						{t('pages.growingUnits.detail.actions.update.title')}
+						{t('features.growingUnits.detail.actions.update.title')}
 					</DialogTitle>
 					<DialogDescription>
-						{t('pages.growingUnits.detail.actions.update.description')}
+						{t('features.growingUnits.detail.actions.update.description')}
 					</DialogDescription>
 				</DialogHeader>
 				<Form errors={formErrors}>
@@ -123,7 +123,7 @@ export function GrowingUnitUpdateForm({
 							<FormControl>
 								<Input
 									placeholder={t(
-										'pages.growingUnits.detail.fields.name.placeholder',
+										'features.growingUnits.detail.fields.name.placeholder',
 									)}
 									disabled={isLoading}
 									value={name}
@@ -299,8 +299,8 @@ export function GrowingUnitUpdateForm({
 							</Button>
 							<Button type="submit" disabled={isLoading}>
 								{isLoading
-									? t('pages.growingUnits.detail.actions.update.loading')
-									: t('pages.growingUnits.detail.actions.update.submit')}
+									? t('features.growingUnits.detail.actions.update.loading')
+									: t('features.growingUnits.detail.actions.update.submit')}
 							</Button>
 						</DialogFooter>
 					</form>

--- a/apps/web/features/growing-units/components/pages/growing-unit-detail-page.tsx
+++ b/apps/web/features/growing-units/components/pages/growing-unit-detail-page.tsx
@@ -146,7 +146,7 @@ export function GrowingUnitDetailPage() {
 								{t('shared.status.growingUnit.active')}
 							</Badge>
 							<span className="text-sm text-muted-foreground">
-								{t('pages.growingUnits.detail.location.label')}:{' '}
+								{t('features.growingUnits.detail.location.label')}:{' '}
 								{t(`shared.status.location.${location}`)}
 							</span>
 							<span className="text-sm text-muted-foreground">|</span>
@@ -164,11 +164,11 @@ export function GrowingUnitDetailPage() {
 						onClick={() => setUpdateDialogOpen(true)}
 					>
 						<PencilIcon className="mr-2 h-4 w-4" />
-						{t('pages.growingUnits.detail.actions.editUnit')}
+						{t('features.growingUnits.detail.actions.editUnit')}
 					</Button>,
 					<Button key="add-plant" onClick={handleAddPlant}>
 						<PlusIcon className="mr-2 h-4 w-4" />
-						{t('pages.growingUnits.detail.actions.addPlant')}
+						{t('features.growingUnits.detail.actions.addPlant')}
 					</Button>,
 				]}
 			/>
@@ -178,13 +178,13 @@ export function GrowingUnitDetailPage() {
 				<Card>
 					<CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
 						<CardTitle className="text-sm font-medium">
-							{t('pages.growingUnits.detail.summary.substrate.label')}
+							{t('features.growingUnits.detail.summary.substrate.label')}
 						</CardTitle>
 						<MountainIcon className="h-4 w-4 text-muted-foreground" />
 					</CardHeader>
 					<CardContent>
 						<div className="text-2xl font-bold">
-							{t('pages.growingUnits.detail.summary.substrate.value')}
+							{t('features.growingUnits.detail.summary.substrate.value')}
 						</div>
 					</CardContent>
 				</Card>
@@ -192,13 +192,13 @@ export function GrowingUnitDetailPage() {
 				<Card>
 					<CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
 						<CardTitle className="text-sm font-medium">
-							{t('pages.growingUnits.detail.summary.exposure.label')}
+							{t('features.growingUnits.detail.summary.exposure.label')}
 						</CardTitle>
 						<SunIcon className="h-4 w-4 text-muted-foreground" />
 					</CardHeader>
 					<CardContent>
 						<div className="text-2xl font-bold">
-							{t('pages.growingUnits.detail.summary.exposure.directSun')}
+							{t('features.growingUnits.detail.summary.exposure.directSun')}
 						</div>
 					</CardContent>
 				</Card>
@@ -206,13 +206,13 @@ export function GrowingUnitDetailPage() {
 				<Card>
 					<CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
 						<CardTitle className="text-sm font-medium">
-							{t('pages.growingUnits.detail.summary.lastWatering.label')}
+							{t('features.growingUnits.detail.summary.lastWatering.label')}
 						</CardTitle>
 						<DropletsIcon className="h-4 w-4 text-muted-foreground" />
 					</CardHeader>
 					<CardContent>
 						<div className="text-2xl font-bold">
-							{t('pages.growingUnits.detail.summary.lastWatering.today')}
+							{t('features.growingUnits.detail.summary.lastWatering.today')}
 						</div>
 						<p className="text-xs text-muted-foreground">08:30 AM</p>
 					</CardContent>
@@ -221,7 +221,7 @@ export function GrowingUnitDetailPage() {
 				<Card>
 					<CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
 						<CardTitle className="text-sm font-medium">
-							{t('pages.growingUnits.detail.summary.occupancy.label')}
+							{t('features.growingUnits.detail.summary.occupancy.label')}
 						</CardTitle>
 						<Grid3x3Icon className="h-4 w-4 text-muted-foreground" />
 					</CardHeader>
@@ -239,7 +239,7 @@ export function GrowingUnitDetailPage() {
 				<CardHeader>
 					<div className="flex items-center justify-between">
 						<CardTitle>
-							{t('pages.growingUnits.detail.sections.plants.title')}
+							{t('features.growingUnits.detail.sections.plants.title')}
 						</CardTitle>
 						<Button variant="link" className="h-auto p-0">
 							{t('common.viewAll')}
@@ -254,19 +254,19 @@ export function GrowingUnitDetailPage() {
 									<TableRow>
 										<TableHead className="w-[80px]">IMG</TableHead>
 										<TableHead>
-											{t('pages.plants.list.table.columns.plant')}
+											{t('features.plants.list.table.columns.plant')}
 										</TableHead>
 										<TableHead>
-											{t('pages.plants.list.table.columns.location')}
+											{t('features.plants.list.table.columns.location')}
 										</TableHead>
 										<TableHead>
-											{t('pages.plants.list.table.columns.status')}
+											{t('features.plants.list.table.columns.status')}
 										</TableHead>
 										<TableHead>
-											{t('pages.plants.list.table.columns.lastWatering')}
+											{t('features.plants.list.table.columns.lastWatering')}
 										</TableHead>
 										<TableHead className="w-[80px]">
-											{t('pages.plants.list.table.columns.actions')}
+											{t('features.plants.list.table.columns.actions')}
 										</TableHead>
 									</TableRow>
 								</TableHeader>
@@ -279,7 +279,7 @@ export function GrowingUnitDetailPage() {
 						</div>
 					) : (
 						<div className="text-center py-8 text-muted-foreground">
-							{t('pages.growingUnits.list.noPlants')}
+							{t('features.growingUnits.list.noPlants')}
 						</div>
 					)}
 				</CardContent>
@@ -291,7 +291,7 @@ export function GrowingUnitDetailPage() {
 				<CardHeader>
 					<div className="flex items-center justify-between">
 						<CardTitle>
-							{t('pages.growingUnits.detail.sections.history.title')}
+							{t('features.growingUnits.detail.sections.history.title')}
 						</CardTitle>
 						<Button variant="link" className="h-auto p-0">
 							{t('common.viewAll')}

--- a/apps/web/features/growing-units/components/pages/growing-units-page.tsx
+++ b/apps/web/features/growing-units/components/pages/growing-units-page.tsx
@@ -38,19 +38,19 @@ export function GrowingUnitsPage() {
 		<div className="mx-auto space-y-6">
 			{/* Header */}
 			<PageHeader
-				title={t('pages.growingUnits.list.title')}
-				description={t('pages.growingUnits.list.description')}
+				title={t('features.growingUnits.list.title')}
+				description={t('features.growingUnits.list.description')}
 				actions={[
 					<Button key="create" onClick={handleAddClick}>
 						<PlusIcon className="mr-2 h-4 w-4" />
-						{t('pages.growingUnits.list.actions.create.button')}
+						{t('features.growingUnits.list.actions.create.button')}
 					</Button>,
 				]}
 			/>
 
 			{/* Search and Filters */}
 			<SearchAndFilters
-				searchPlaceholder={t('pages.growingUnits.list.search.placeholder')}
+				searchPlaceholder={t('features.growingUnits.list.search.placeholder')}
 				searchValue={searchQuery}
 				onSearchChange={setSearchQuery}
 				filterOptions={filterOptions}
@@ -64,7 +64,7 @@ export function GrowingUnitsPage() {
 			) : growingUnitsError ? (
 				<div className="flex items-center justify-center min-h-[400px]">
 					<p className="text-destructive">
-						{t('pages.growingUnits.list.error.loading', {
+						{t('features.growingUnits.list.error.loading', {
 							message: growingUnitsError.message,
 						})}
 					</p>

--- a/apps/web/features/growing-units/hooks/use-growing-units-page/use-growing-units-page.ts
+++ b/apps/web/features/growing-units/hooks/use-growing-units-page/use-growing-units-page.ts
@@ -122,25 +122,25 @@ export function useGrowingUnitsPage() {
 
 	const filterOptions: FilterOption[] = useMemo(
 		() => [
-			{ value: 'all', label: t('pages.growingUnits.list.filters.all') },
+			{ value: 'all', label: t('features.growingUnits.list.filters.all') },
 			{
 				value: 'indoor',
-				label: t('pages.growingUnits.list.filters.indoor'),
+				label: t('features.growingUnits.list.filters.indoor'),
 				icon: HomeIcon,
 			},
 			{
 				value: 'outdoor',
-				label: t('pages.growingUnits.list.filters.outdoor'),
+				label: t('features.growingUnits.list.filters.outdoor'),
 				icon: Building2Icon,
 			},
 			{
 				value: 'pots',
-				label: t('pages.growingUnits.list.filters.pots'),
+				label: t('features.growingUnits.list.filters.pots'),
 				icon: FlowerIcon,
 			},
 			{
 				value: 'beds',
-				label: t('pages.growingUnits.list.filters.beds'),
+				label: t('features.growingUnits.list.filters.beds'),
 				icon: PackageIcon,
 			},
 		],

--- a/apps/web/features/growing-units/locales/en.json
+++ b/apps/web/features/growing-units/locales/en.json
@@ -1,0 +1,177 @@
+{
+  "list": {
+    "title": "Growing Units",
+    "description": "Visualize and manage your cultivation spaces efficiently.",
+    "empty": "No growing units available",
+    "search": {
+      "placeholder": "Search by name, type or plant..."
+    },
+    "filters": {
+      "all": "All",
+      "indoor": "Indoor",
+      "outdoor": "Outdoor",
+      "pots": "Pots",
+      "beds": "Beds"
+    },
+    "actions": {
+      "create": {
+        "button": "Create Growing Unit",
+        "title": "Create Growing Unit",
+        "description": "Add a new growing unit for your plants",
+        "submit": "Create",
+        "loading": "Creating..."
+      }
+    },
+    "noPlants": "No active plants",
+    "common": {
+      "noDimensions": "No dimensions"
+    }
+  },
+  "detail": {
+    "title": "Growing Unit Detail",
+    "notFound": "Growing unit not found",
+    "error": {
+      "loading": "Error loading growing unit: {message}"
+    },
+    "breadcrumbs": {
+      "home": "Home",
+      "growingUnits": "My Units"
+    },
+    "status": {
+      "active": "ACTIVE",
+      "inactive": "INACTIVE"
+    },
+    "location": {
+      "label": "Location",
+      "indoor": "Indoor",
+      "outdoor": "Outdoor"
+    },
+    "summary": {
+      "substrate": {
+        "label": "Substrate",
+        "value": "Universal Soil"
+      },
+      "exposure": {
+        "label": "Exposure",
+        "directSun": "Direct Sun",
+        "partialSun": "Partial Sun",
+        "shade": "Shade"
+      },
+      "lastWatering": {
+        "label": "Last Watering",
+        "today": "Today",
+        "yesterday": "Yesterday",
+        "never": "Never"
+      },
+      "occupancy": {
+        "label": "Occupancy"
+      }
+    },
+    "sections": {
+      "plants": {
+        "title": "Plants in cultivation",
+        "viewAll": "View all",
+        "variety": "Variety",
+        "planted": "PLANTED",
+        "days": "days",
+        "manage": "Manage"
+      },
+      "history": {
+        "title": "Recent History",
+        "viewAll": "View all history",
+        "today": "TODAY",
+        "yesterday": "YESTERDAY"
+      }
+    },
+    "actions": {
+      "editUnit": "Edit Unit",
+      "addPlant": "Add Plant",
+      "update": {
+        "title": "Update Growing Unit",
+        "description": "Update growing unit information",
+        "submit": "Update",
+        "loading": "Updating..."
+      },
+      "delete": {
+        "label": "Delete",
+        "loading": "Deleting...",
+        "confirm": {
+          "title": "Delete Growing Unit",
+          "description": "Are you sure you want to delete the growing unit {name}? This action cannot be undone."
+        }
+      }
+    },
+    "fields": {
+      "name": {
+        "label": "Name",
+        "placeholder": "Growing unit name"
+      },
+      "type": {
+        "label": "Type",
+        "placeholder": "Select type"
+      },
+      "capacity": {
+        "label": "Capacity",
+        "placeholder": "Number of plants"
+      },
+      "remainingCapacity": {
+        "label": "Remaining Capacity"
+      },
+      "volume": {
+        "label": "Volume"
+      },
+      "dimensions": {
+        "label": "Dimensions"
+      },
+      "length": {
+        "label": "Length",
+        "placeholder": "Length"
+      },
+      "width": {
+        "label": "Width",
+        "placeholder": "Width"
+      },
+      "height": {
+        "label": "Height",
+        "placeholder": "Height"
+      },
+      "unit": {
+        "label": "Unit",
+        "placeholder": "Select unit"
+      },
+      "plants": {
+        "label": "Active plants"
+      },
+      "createdAt": {
+        "label": "Created at"
+      }
+    }
+  },
+  "types": {
+    "POT": "Pot",
+    "GARDEN_BED": "Garden Bed",
+    "HANGING_BASKET": "Hanging Basket",
+    "WINDOW_BOX": "Window Box"
+  },
+  "units": {
+    "MILLIMETER": "Millimeter",
+    "CENTIMETER": "Centimeter",
+    "METER": "Meter",
+    "INCH": "Inch",
+    "FOOT": "Foot"
+  },
+  "validation": {
+    "id": {
+      "required": "ID is required"
+    },
+    "name": {
+      "required": "Name is required"
+    },
+    "type": {
+      "invalid": "Invalid type"
+    },
+    "capacity": {
+      "required": "Capacity is required"
+    }
+  }
+}

--- a/apps/web/features/growing-units/locales/es.json
+++ b/apps/web/features/growing-units/locales/es.json
@@ -1,0 +1,177 @@
+{
+  "list": {
+    "title": "Unidades de Cultivo",
+    "description": "Visualiza y gestiona tus espacios de cultivo de manera eficiente.",
+    "empty": "No hay unidades de cultivo disponibles",
+    "search": {
+      "placeholder": "Buscar por nombre, tipo o planta..."
+    },
+    "filters": {
+      "all": "Todo",
+      "indoor": "Interior",
+      "outdoor": "Exterior",
+      "pots": "Macetas",
+      "beds": "Bancales"
+    },
+    "actions": {
+      "create": {
+        "button": "Nueva Unidad",
+        "title": "Crear Unidad de Cultivo",
+        "description": "Agrega una nueva unidad de cultivo para tus plantas",
+        "submit": "Crear",
+        "loading": "Creando..."
+      }
+    },
+    "noPlants": "Sin plantas activas",
+    "common": {
+      "noDimensions": "Sin dimensiones"
+    }
+  },
+  "detail": {
+    "title": "Detalle de Unidad de Cultivo",
+    "notFound": "Unidad de cultivo no encontrada",
+    "error": {
+      "loading": "Error al cargar unidad de cultivo: {message}"
+    },
+    "breadcrumbs": {
+      "home": "Inicio",
+      "growingUnits": "Mis Unidades"
+    },
+    "status": {
+      "active": "ACTIVA",
+      "inactive": "INACTIVA"
+    },
+    "location": {
+      "label": "Ubicación",
+      "indoor": "Interior",
+      "outdoor": "Exterior"
+    },
+    "summary": {
+      "substrate": {
+        "label": "Sustrato",
+        "value": "Tierra Universal"
+      },
+      "exposure": {
+        "label": "Exposición",
+        "directSun": "Sol Directo",
+        "partialSun": "Sol Parcial",
+        "shade": "Sombra"
+      },
+      "lastWatering": {
+        "label": "Último Riego",
+        "today": "Hoy",
+        "yesterday": "Ayer",
+        "never": "Nunca"
+      },
+      "occupancy": {
+        "label": "Ocupación"
+      }
+    },
+    "sections": {
+      "plants": {
+        "title": "Plantas en cultivo",
+        "viewAll": "Ver todas",
+        "variety": "Variedad",
+        "planted": "PLANTADO",
+        "days": "días",
+        "manage": "Gestionar"
+      },
+      "history": {
+        "title": "Historial Reciente",
+        "viewAll": "Ver todo el historial",
+        "today": "HOY",
+        "yesterday": "AYER"
+      }
+    },
+    "actions": {
+      "editUnit": "Editar Unidad",
+      "addPlant": "Agregar Planta",
+      "update": {
+        "title": "Actualizar Unidad de Cultivo",
+        "description": "Actualizar información de la unidad de cultivo",
+        "submit": "Actualizar",
+        "loading": "Actualizando..."
+      },
+      "delete": {
+        "label": "Eliminar",
+        "loading": "Eliminando...",
+        "confirm": {
+          "title": "Eliminar Unidad de Cultivo",
+          "description": "¿Estás seguro de que quieres eliminar la unidad de cultivo {name}? Esta acción no se puede deshacer."
+        }
+      }
+    },
+    "fields": {
+      "name": {
+        "label": "Nombre",
+        "placeholder": "Nombre de la unidad de cultivo"
+      },
+      "type": {
+        "label": "Tipo",
+        "placeholder": "Selecciona el tipo"
+      },
+      "capacity": {
+        "label": "Capacidad",
+        "placeholder": "Número de plantas"
+      },
+      "remainingCapacity": {
+        "label": "Capacidad Restante"
+      },
+      "volume": {
+        "label": "Volumen"
+      },
+      "dimensions": {
+        "label": "Dimensiones"
+      },
+      "length": {
+        "label": "Longitud",
+        "placeholder": "Longitud"
+      },
+      "width": {
+        "label": "Ancho",
+        "placeholder": "Ancho"
+      },
+      "height": {
+        "label": "Altura",
+        "placeholder": "Altura"
+      },
+      "unit": {
+        "label": "Unidad",
+        "placeholder": "Selecciona la unidad"
+      },
+      "plants": {
+        "label": "Plantas activas"
+      },
+      "createdAt": {
+        "label": "Fecha de creación"
+      }
+    }
+  },
+  "types": {
+    "POT": "Maceta",
+    "GARDEN_BED": "Cama de jardín",
+    "HANGING_BASKET": "Cesta colgante",
+    "WINDOW_BOX": "Jardín de ventana"
+  },
+  "units": {
+    "MILLIMETER": "Milímetro",
+    "CENTIMETER": "Centímetro",
+    "METER": "Metro",
+    "INCH": "Pulgada",
+    "FOOT": "Pie"
+  },
+  "validation": {
+    "id": {
+      "required": "El ID es requerido"
+    },
+    "name": {
+      "required": "El nombre es requerido"
+    },
+    "type": {
+      "invalid": "Tipo inválido"
+    },
+    "capacity": {
+      "required": "La capacidad es requerida"
+    }
+  }
+}

--- a/apps/web/features/locations/components/organisms/location-add-card/location-add-card.tsx
+++ b/apps/web/features/locations/components/organisms/location-add-card/location-add-card.tsx
@@ -19,10 +19,10 @@ export function LocationAddCard({ onClick }: LocationAddCardProps) {
 			<CardContent className="flex flex-col items-center justify-center min-h-[300px] p-6">
 				<PlusIcon className="h-12 w-12 text-muted-foreground mb-4" />
 				<h3 className="text-lg font-semibold mb-2">
-					{t('pages.locations.list.actions.create.button')}
+					{t('features.locations.list.actions.create.button')}
 				</h3>
 				<p className="text-sm text-muted-foreground text-center">
-					{t('pages.locations.list.actions.create.description')}
+					{t('features.locations.list.actions.create.description')}
 				</p>
 			</CardContent>
 		</Card>

--- a/apps/web/features/locations/components/organisms/location-card/location-card.tsx
+++ b/apps/web/features/locations/components/organisms/location-card/location-card.tsx
@@ -115,7 +115,7 @@ export function LocationCard({
 					</div>
 				) : (
 					<div className="text-sm text-muted-foreground">
-						{t('pages.locations.list.noDescription')}
+						{t('features.locations.list.noDescription')}
 					</div>
 				)}
 			</CardContent>

--- a/apps/web/features/locations/components/organisms/location-create-form/location-create-form.tsx
+++ b/apps/web/features/locations/components/organisms/location-create-form/location-create-form.tsx
@@ -68,10 +68,10 @@ export function LocationCreateForm({
 			<DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
 				<DialogHeader>
 					<DialogTitle>
-						{t('pages.locations.list.actions.create.title')}
+						{t('features.locations.list.actions.create.title')}
 					</DialogTitle>
 					<DialogDescription>
-						{t('pages.locations.list.actions.create.description')}
+						{t('features.locations.list.actions.create.description')}
 					</DialogDescription>
 				</DialogHeader>
 				<Form errors={formErrors}>
@@ -158,8 +158,8 @@ export function LocationCreateForm({
 							</Button>
 							<Button type="submit" disabled={isLoading}>
 								{isLoading
-									? t('pages.locations.list.actions.create.loading')
-									: t('pages.locations.list.actions.create.submit')}
+									? t('features.locations.list.actions.create.loading')
+									: t('features.locations.list.actions.create.submit')}
 							</Button>
 						</DialogFooter>
 					</form>

--- a/apps/web/features/locations/components/organisms/location-delete-dialog/location-delete-dialog.tsx
+++ b/apps/web/features/locations/components/organisms/location-delete-dialog/location-delete-dialog.tsx
@@ -39,10 +39,10 @@ export function LocationDeleteDialog({
 			<AlertDialogContent>
 				<AlertDialogHeader>
 					<AlertDialogTitle>
-						{t('pages.locations.list.actions.delete.confirm.title')}
+						{t('features.locations.list.actions.delete.confirm.title')}
 					</AlertDialogTitle>
 					<AlertDialogDescription>
-						{t('pages.locations.list.actions.delete.confirm.description', {
+						{t('features.locations.list.actions.delete.confirm.description', {
 							name: location.name,
 						})}
 					</AlertDialogDescription>
@@ -57,7 +57,7 @@ export function LocationDeleteDialog({
 						className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
 					>
 						{isLoading
-							? t('pages.locations.list.actions.delete.loading')
+							? t('features.locations.list.actions.delete.loading')
 							: t('common.delete')}
 					</AlertDialogAction>
 				</AlertDialogFooter>

--- a/apps/web/features/locations/components/organisms/location-update-form/location-update-form.tsx
+++ b/apps/web/features/locations/components/organisms/location-update-form/location-update-form.tsx
@@ -76,10 +76,10 @@ export function LocationUpdateForm({
 			<DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
 				<DialogHeader>
 					<DialogTitle>
-						{t('pages.locations.list.actions.update.title')}
+						{t('features.locations.list.actions.update.title')}
 					</DialogTitle>
 					<DialogDescription>
-						{t('pages.locations.list.actions.update.description')}
+						{t('features.locations.list.actions.update.description')}
 					</DialogDescription>
 				</DialogHeader>
 				<Form errors={formErrors}>
@@ -166,8 +166,8 @@ export function LocationUpdateForm({
 							</Button>
 							<Button type="submit" disabled={isLoading}>
 								{isLoading
-									? t('pages.locations.list.actions.update.loading')
-									: t('pages.locations.list.actions.update.submit')}
+									? t('features.locations.list.actions.update.loading')
+									: t('features.locations.list.actions.update.submit')}
 							</Button>
 						</DialogFooter>
 					</form>

--- a/apps/web/features/locations/components/pages/locations-page.tsx
+++ b/apps/web/features/locations/components/pages/locations-page.tsx
@@ -52,19 +52,19 @@ export function LocationsPage() {
 		<div className="mx-auto space-y-6">
 			{/* Header */}
 			<PageHeader
-				title={t('pages.locations.list.title')}
-				description={t('pages.locations.list.description')}
+				title={t('features.locations.list.title')}
+				description={t('features.locations.list.description')}
 				actions={[
 					<Button key="create" onClick={handleAddClick}>
 						<PlusIcon className="mr-2 h-4 w-4" />
-						{t('pages.locations.list.actions.create.button')}
+						{t('features.locations.list.actions.create.button')}
 					</Button>,
 				]}
 			/>
 
 			{/* Search and Filters */}
 			<SearchAndFilters
-				searchPlaceholder={t('pages.locations.list.search.placeholder')}
+				searchPlaceholder={t('features.locations.list.search.placeholder')}
 				searchValue={searchQuery}
 				onSearchChange={setSearchQuery}
 				filterOptions={filterOptions}
@@ -78,7 +78,7 @@ export function LocationsPage() {
 			) : locationsError ? (
 				<div className="flex items-center justify-center min-h-[400px]">
 					<p className="text-destructive">
-						{t('pages.locations.list.error.loading', {
+						{t('features.locations.list.error.loading', {
 							message: locationsError.message,
 						})}
 					</p>

--- a/apps/web/features/locations/hooks/use-locations-page/use-locations-page.ts
+++ b/apps/web/features/locations/hooks/use-locations-page/use-locations-page.ts
@@ -88,15 +88,15 @@ export function useLocationsPage() {
 
 	const filterOptions: FilterOption[] = useMemo(
 		() => [
-			{ value: 'all', label: t('pages.locations.list.filters.all') },
+			{ value: 'all', label: t('features.locations.list.filters.all') },
 			{
 				value: 'indoor',
-				label: t('pages.locations.list.filters.indoor'),
+				label: t('features.locations.list.filters.indoor'),
 				icon: HomeIcon,
 			},
 			{
 				value: 'outdoor',
-				label: t('pages.locations.list.filters.outdoor'),
+				label: t('features.locations.list.filters.outdoor'),
 				icon: Building2Icon,
 			},
 		],

--- a/apps/web/features/locations/locales/en.json
+++ b/apps/web/features/locations/locales/en.json
@@ -1,0 +1,50 @@
+{
+  "list": {
+    "title": "Locations",
+    "description": "Manage your locations and organize your growing spaces.",
+    "empty": "No locations available",
+    "noDescription": "No description available",
+    "search": {
+      "placeholder": "Search by name or type..."
+    },
+    "filters": {
+      "all": "All",
+      "indoor": "Indoor",
+      "outdoor": "Outdoor"
+    },
+    "actions": {
+      "create": {
+        "button": "Create Location",
+        "title": "Create Location",
+        "description": "Add a new location for your growing spaces",
+        "submit": "Create",
+        "loading": "Creating..."
+      },
+      "update": {
+        "title": "Update Location",
+        "description": "Update location information",
+        "submit": "Update",
+        "loading": "Updating..."
+      },
+      "delete": {
+        "label": "Delete",
+        "loading": "Deleting...",
+        "confirm": {
+          "title": "Delete Location",
+          "description": "Are you sure you want to delete the location {name}? This action cannot be undone."
+        }
+      }
+    },
+    "error": {
+      "loading": "Error loading locations: {message}"
+    }
+  },
+  "types": {
+    "ROOM": "Room",
+    "BALCONY": "Balcony",
+    "GARDEN": "Garden",
+    "GREENHOUSE": "Greenhouse",
+    "OUTDOOR_SPACE": "Outdoor Space",
+    "INDOOR_SPACE": "Indoor Space"
+  }
+}

--- a/apps/web/features/locations/locales/es.json
+++ b/apps/web/features/locations/locales/es.json
@@ -1,0 +1,50 @@
+{
+  "list": {
+    "title": "Ubicaciones",
+    "description": "Gestiona tus ubicaciones y organiza tus espacios de cultivo.",
+    "empty": "No hay ubicaciones disponibles",
+    "noDescription": "Sin descripción disponible",
+    "search": {
+      "placeholder": "Buscar por nombre o tipo..."
+    },
+    "filters": {
+      "all": "Todas",
+      "indoor": "Interior",
+      "outdoor": "Exterior"
+    },
+    "actions": {
+      "create": {
+        "button": "Crear Ubicación",
+        "title": "Crear Ubicación",
+        "description": "Agrega una nueva ubicación para tus espacios de cultivo",
+        "submit": "Crear",
+        "loading": "Creando..."
+      },
+      "update": {
+        "title": "Actualizar Ubicación",
+        "description": "Actualizar información de la ubicación",
+        "submit": "Actualizar",
+        "loading": "Actualizando..."
+      },
+      "delete": {
+        "label": "Eliminar",
+        "loading": "Eliminando...",
+        "confirm": {
+          "title": "Eliminar Ubicación",
+          "description": "¿Estás seguro de que quieres eliminar la ubicación {name}? Esta acción no se puede deshacer."
+        }
+      }
+    },
+    "error": {
+      "loading": "Error al cargar ubicaciones: {message}"
+    }
+  },
+  "types": {
+    "ROOM": "Habitación",
+    "BALCONY": "Balcón",
+    "GARDEN": "Jardín",
+    "GREENHOUSE": "Invernadero",
+    "OUTDOOR_SPACE": "Espacio Exterior",
+    "INDOOR_SPACE": "Espacio Interior"
+  }
+}

--- a/apps/web/features/plants/components/organisms/plant-create-form/plant-create-form.tsx
+++ b/apps/web/features/plants/components/organisms/plant-create-form/plant-create-form.tsx
@@ -100,7 +100,7 @@ export function PlantCreateForm({
 										<SelectTrigger>
 											<SelectValue
 												placeholder={t(
-													'pages.plants.detail.fields.growingUnitId.placeholder',
+													'features.plants.detail.fields.growingUnitId.placeholder',
 												)}
 											/>
 										</SelectTrigger>
@@ -120,12 +120,12 @@ export function PlantCreateForm({
 						<div className="grid grid-cols-2 gap-4">
 							<FormItem>
 								<FormLabel>
-									{t('pages.plants.detail.fields.name.label')}
+									{t('features.plants.detail.fields.name.label')}
 								</FormLabel>
 								<FormControl>
 									<Input
 										placeholder={t(
-											'pages.plants.detail.fields.name.placeholder',
+											'features.plants.detail.fields.name.placeholder',
 										)}
 										disabled={isLoading}
 										value={name}
@@ -238,8 +238,8 @@ export function PlantCreateForm({
 							</Button>
 							<Button type="submit" disabled={isLoading}>
 								{isLoading
-									? t('pages.plants.list.actions.create.loading')
-									: t('pages.plants.list.actions.create.submit')}
+									? t('features.plants.list.actions.create.loading')
+									: t('features.plants.list.actions.create.submit')}
 							</Button>
 						</DialogFooter>
 					</form>

--- a/apps/web/features/plants/components/organisms/plant-edit-details-modal/plant-edit-details-modal.tsx
+++ b/apps/web/features/plants/components/organisms/plant-edit-details-modal/plant-edit-details-modal.tsx
@@ -77,10 +77,10 @@ export function PlantEditDetailsModal({
 			<DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
 				<DialogHeader>
 					<DialogTitle>
-						{t('pages.plants.detail.modals.editDetails.title')}
+						{t('features.plants.detail.modals.editDetails.title')}
 					</DialogTitle>
 					<DialogDescription>
-						{t('pages.plants.detail.modals.editDetails.description')}
+						{t('features.plants.detail.modals.editDetails.description')}
 					</DialogDescription>
 				</DialogHeader>
 				<Form errors={formErrors}>
@@ -88,12 +88,12 @@ export function PlantEditDetailsModal({
 						<div className="grid grid-cols-2 gap-4">
 							<FormItem>
 								<FormLabel>
-									{t('pages.plants.detail.fields.name.label')}
+									{t('features.plants.detail.fields.name.label')}
 								</FormLabel>
 								<FormControl>
 									<Input
 										placeholder={t(
-											'pages.plants.detail.fields.name.placeholder',
+											'features.plants.detail.fields.name.placeholder',
 										)}
 										disabled={isLoading}
 										value={name}
@@ -120,7 +120,7 @@ export function PlantEditDetailsModal({
 						<div className="grid grid-cols-2 gap-4">
 							<FormItem>
 								<FormLabel>
-									{t('pages.plants.detail.fields.plantedDate.label')}
+									{t('features.plants.detail.fields.plantedDate.label')}
 								</FormLabel>
 								<FormControl>
 									<Input
@@ -209,10 +209,10 @@ export function PlantEditDetailsModal({
 							<Button type="submit" disabled={isLoading}>
 								{isLoading
 									? t(
-											'pages.plants.detail.modals.editDetails.actions.submit.loading',
+											'features.plants.detail.modals.editDetails.actions.submit.loading',
 										)
 									: t(
-											'pages.plants.detail.modals.editDetails.actions.submit.label',
+											'features.plants.detail.modals.editDetails.actions.submit.label',
 										)}
 							</Button>
 						</DialogFooter>

--- a/apps/web/features/plants/components/organisms/plant-table-row/plant-table-row.tsx
+++ b/apps/web/features/plants/components/organisms/plant-table-row/plant-table-row.tsx
@@ -56,7 +56,7 @@ export function PlantTableRow({ plant, onEdit, onDelete }: PlantTableRowProps) {
 			<TableCell>
 				<div>
 					<div className="font-medium">
-						{plant.name || t('pages.plants.detail.unnamed')}
+						{plant.name || t('features.plants.detail.unnamed')}
 					</div>
 					<div className="text-sm text-muted-foreground">
 						{plant.species || '-'}
@@ -82,12 +82,12 @@ export function PlantTableRow({ plant, onEdit, onDelete }: PlantTableRowProps) {
 			<TableCell>
 				<span className="text-sm text-muted-foreground">
 					{formatPlantDate(plant.updatedAt, {
-						today: t('pages.plants.list.table.lastWatering.today'),
-						yesterday: t('pages.plants.list.table.lastWatering.yesterday'),
+						today: t('features.plants.list.table.lastWatering.today'),
+						yesterday: t('features.plants.list.table.lastWatering.yesterday'),
 						daysAgo: (days: number) =>
-							t('pages.plants.list.table.lastWatering.daysAgo', { days }),
+							t('features.plants.list.table.lastWatering.daysAgo', { days }),
 						weeksAgo: (weeks: number) =>
-							t('pages.plants.list.table.lastWatering.weeksAgo', { weeks }),
+							t('features.plants.list.table.lastWatering.weeksAgo', { weeks }),
 					})}
 				</span>
 			</TableCell>
@@ -102,11 +102,11 @@ export function PlantTableRow({ plant, onEdit, onDelete }: PlantTableRowProps) {
 						<DropdownMenuItem
 							onClick={() => router.push(`/${locale}/plants/${plant.id}`)}
 						>
-							{t('pages.plants.list.actions.view')}
+							{t('features.plants.list.actions.view')}
 						</DropdownMenuItem>
 						{onEdit && (
 							<DropdownMenuItem onClick={() => onEdit(plant)}>
-								{t('pages.plants.list.actions.edit')}
+								{t('features.plants.list.actions.edit')}
 							</DropdownMenuItem>
 						)}
 						{onDelete && (
@@ -114,7 +114,7 @@ export function PlantTableRow({ plant, onEdit, onDelete }: PlantTableRowProps) {
 								onClick={() => onDelete(plant.id)}
 								className="text-destructive"
 							>
-								{t('pages.plants.list.actions.delete')}
+								{t('features.plants.list.actions.delete')}
 							</DropdownMenuItem>
 						)}
 					</DropdownMenuContent>

--- a/apps/web/features/plants/components/organisms/plant-transplant-modal/plant-transplant-modal.tsx
+++ b/apps/web/features/plants/components/organisms/plant-transplant-modal/plant-transplant-modal.tsx
@@ -75,10 +75,10 @@ export function PlantTransplantModal({
 			<DialogContent>
 				<DialogHeader>
 					<DialogTitle>
-						{t('pages.plants.detail.modals.transplant.title')}
+						{t('features.plants.detail.modals.transplant.title')}
 					</DialogTitle>
 					<DialogDescription>
-						{t('pages.plants.detail.modals.transplant.description')}
+						{t('features.plants.detail.modals.transplant.description')}
 					</DialogDescription>
 				</DialogHeader>
 
@@ -88,14 +88,14 @@ export function PlantTransplantModal({
 						<FormItem>
 							<FormLabel>
 								{t(
-									'pages.plants.detail.modals.transplant.fields.sourceGrowingUnit.label',
+									'features.plants.detail.modals.transplant.fields.sourceGrowingUnit.label',
 								)}
 							</FormLabel>
 							<Input
 								value={
 									sourceGrowingUnit?.name ||
 									t(
-										'pages.plants.detail.modals.transplant.fields.sourceGrowingUnit.unknown',
+										'features.plants.detail.modals.transplant.fields.sourceGrowingUnit.unknown',
 									)
 								}
 								disabled
@@ -103,7 +103,7 @@ export function PlantTransplantModal({
 							/>
 							<p className="text-xs text-muted-foreground">
 								{t(
-									'pages.plants.detail.modals.transplant.fields.sourceGrowingUnit.helper',
+									'features.plants.detail.modals.transplant.fields.sourceGrowingUnit.helper',
 								)}
 							</p>
 						</FormItem>
@@ -112,7 +112,7 @@ export function PlantTransplantModal({
 						<FormItem>
 							<FormLabel>
 								{t(
-									'pages.plants.detail.modals.transplant.fields.targetGrowingUnitId.label',
+									'features.plants.detail.modals.transplant.fields.targetGrowingUnitId.label',
 								)}
 							</FormLabel>
 							<Select
@@ -124,7 +124,7 @@ export function PlantTransplantModal({
 									<SelectTrigger>
 										<SelectValue
 											placeholder={t(
-												'pages.plants.detail.modals.transplant.fields.targetGrowingUnitId.placeholder',
+												'features.plants.detail.modals.transplant.fields.targetGrowingUnitId.placeholder',
 											)}
 										/>
 									</SelectTrigger>
@@ -135,7 +135,7 @@ export function PlantTransplantModal({
 											{growingUnit.name} ({growingUnit.remainingCapacity}/
 											{growingUnit.capacity}{' '}
 											{t(
-												'pages.plants.detail.modals.transplant.fields.targetGrowingUnitId.capacityAvailable',
+												'features.plants.detail.modals.transplant.fields.targetGrowingUnitId.capacityAvailable',
 											)}
 											)
 										</SelectItem>
@@ -161,10 +161,10 @@ export function PlantTransplantModal({
 							<Button type="submit" disabled={isLoading}>
 								{isLoading
 									? t(
-											'pages.plants.detail.modals.transplant.actions.submit.loading',
+											'features.plants.detail.modals.transplant.actions.submit.loading',
 										)
 									: t(
-											'pages.plants.detail.modals.transplant.actions.submit.label',
+											'features.plants.detail.modals.transplant.actions.submit.label',
 										)}
 							</Button>
 						</DialogFooter>

--- a/apps/web/features/plants/components/organisms/plants-by-growing-unit-section/plants-by-growing-unit-section.tsx
+++ b/apps/web/features/plants/components/organisms/plants-by-growing-unit-section/plants-by-growing-unit-section.tsx
@@ -51,7 +51,7 @@ export function PlantsByGrowingUnitSection({
 				<div>
 					<h3 className="text-lg font-semibold">{growingUnit.name}</h3>
 					<p className="text-sm text-muted-foreground">
-						{t('pages.plants.list.growingUnit.plantCount', {
+						{t('features.plants.list.growingUnit.plantCount', {
 							count: filteredPlants.length,
 							total: growingUnit.numberOfPlants,
 						})}
@@ -66,19 +66,19 @@ export function PlantsByGrowingUnitSection({
 						<TableRow>
 							<TableHead className="w-[80px]">IMG</TableHead>
 							<TableHead>
-								{t('pages.plants.list.table.columns.plant')}
+								{t('features.plants.list.table.columns.plant')}
 							</TableHead>
 							<TableHead>
-								{t('pages.plants.list.table.columns.location')}
+								{t('features.plants.list.table.columns.location')}
 							</TableHead>
 							<TableHead>
-								{t('pages.plants.list.table.columns.status')}
+								{t('features.plants.list.table.columns.status')}
 							</TableHead>
 							<TableHead>
-								{t('pages.plants.list.table.columns.lastWatering')}
+								{t('features.plants.list.table.columns.lastWatering')}
 							</TableHead>
 							<TableHead className="w-[80px]">
-								{t('pages.plants.list.table.columns.actions')}
+								{t('features.plants.list.table.columns.actions')}
 							</TableHead>
 						</TableRow>
 					</TableHeader>

--- a/apps/web/features/plants/components/pages/plant-detail-page.tsx
+++ b/apps/web/features/plants/components/pages/plant-detail-page.tsx
@@ -75,7 +75,7 @@ export function PlantDetailPage() {
 			<div className="mx-auto py-8">
 				<div className="flex items-center justify-center min-h-[400px]">
 					<p className="text-destructive">
-						{t('pages.plants.detail.error.loading', {
+						{t('features.plants.detail.error.loading', {
 							message: (error as Error)?.message || 'Unknown error',
 						})}
 					</p>
@@ -104,7 +104,7 @@ export function PlantDetailPage() {
 								<div className="flex items-start justify-between gap-4">
 									<div className="space-y-1">
 										<h1 className="text-3xl font-bold">
-											{plant.name || t('pages.plants.detail.unnamed')}
+											{plant.name || t('features.plants.detail.unnamed')}
 										</h1>
 										<p className="text-muted-foreground">
 											{plant.species || t('common.notSet')} • Araceae
@@ -113,7 +113,7 @@ export function PlantDetailPage() {
 									<div className="flex items-center gap-2 flex-wrap">
 										{getPlantStatusBadge(plant.status, t)}
 										<Badge variant="outline">
-											{t('pages.plants.detail.location.indoor')}
+											{t('features.plants.detail.location.indoor')}
 										</Badge>
 									</div>
 								</div>
@@ -125,27 +125,27 @@ export function PlantDetailPage() {
 									<div className="flex items-center gap-2 text-sm text-muted-foreground">
 										<DropletsIcon className="h-4 w-4" />
 										<span>
-											{t('pages.plants.detail.metrics.watering.label')}
+											{t('features.plants.detail.metrics.watering.label')}
 										</span>
 									</div>
 									<p className="font-medium">
-										{t('pages.plants.detail.metrics.watering.every7Days')}
+										{t('features.plants.detail.metrics.watering.every7Days')}
 									</p>
 								</div>
 								<div className="space-y-1">
 									<div className="flex items-center gap-2 text-sm text-muted-foreground">
 										<SunIcon className="h-4 w-4" />
-										<span>{t('pages.plants.detail.metrics.light.label')}</span>
+										<span>{t('features.plants.detail.metrics.light.label')}</span>
 									</div>
 									<p className="font-medium">
-										{t('pages.plants.detail.metrics.light.indirect')}
+										{t('features.plants.detail.metrics.light.indirect')}
 									</p>
 								</div>
 								<div className="space-y-1">
 									<div className="flex items-center gap-2 text-sm text-muted-foreground">
 										<ThermometerIcon className="h-4 w-4" />
 										<span>
-											{t('pages.plants.detail.metrics.temperature.label')}
+											{t('features.plants.detail.metrics.temperature.label')}
 										</span>
 									</div>
 									<p className="font-medium">18-24°C</p>
@@ -154,11 +154,11 @@ export function PlantDetailPage() {
 									<div className="flex items-center gap-2 text-sm text-muted-foreground">
 										<CloudIcon className="h-4 w-4" />
 										<span>
-											{t('pages.plants.detail.metrics.humidity.label')}
+											{t('features.plants.detail.metrics.humidity.label')}
 										</span>
 									</div>
 									<p className="font-medium">
-										{t('pages.plants.detail.metrics.humidity.high')}
+										{t('features.plants.detail.metrics.humidity.high')}
 									</p>
 								</div>
 							</div>
@@ -170,22 +170,22 @@ export function PlantDetailPage() {
 									onClick={() => setEditDetailsDialogOpen(true)}
 								>
 									<PencilIcon className="mr-2 h-4 w-4" />
-									{t('pages.plants.detail.actions.editDetails')}
+									{t('features.plants.detail.actions.editDetails')}
 								</Button>
 								<Button variant="outline">
 									<DropletsIcon className="mr-2 h-4 w-4" />
-									{t('pages.plants.detail.actions.registerWatering')}
+									{t('features.plants.detail.actions.registerWatering')}
 								</Button>
 								<Button variant="outline">
 									<FlowerIcon className="mr-2 h-4 w-4" />
-									{t('pages.plants.detail.actions.fertilize')}
+									{t('features.plants.detail.actions.fertilize')}
 								</Button>
 								<Button
 									variant="outline"
 									onClick={() => setTransplantDialogOpen(true)}
 								>
 									<ArrowRightLeftIcon className="mr-2 h-4 w-4" />
-									{t('pages.plants.detail.actions.transplant')}
+									{t('features.plants.detail.actions.transplant')}
 								</Button>
 								<Button variant="ghost" size="icon">
 									<TrashIcon className="h-4 w-4 text-destructive" />
@@ -201,14 +201,14 @@ export function PlantDetailPage() {
 				<Card>
 					<CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
 						<CardTitle className="text-sm font-medium">
-							{t('pages.plants.detail.currentStatus.lastWatering.label')}
+							{t('features.plants.detail.currentStatus.lastWatering.label')}
 						</CardTitle>
 						<DropletsIcon className="h-4 w-4 text-muted-foreground" />
 					</CardHeader>
 					<CardContent>
 						<div className="flex items-center gap-2 mb-2">
 							<Badge variant="default" className="bg-green-500">
-								{t('pages.plants.detail.currentStatus.lastWatering.onTime')}
+								{t('features.plants.detail.currentStatus.lastWatering.onTime')}
 							</Badge>
 						</div>
 						<div className="text-2xl font-bold">
@@ -217,7 +217,7 @@ export function PlantDetailPage() {
 							})}
 						</div>
 						<p className="text-xs text-muted-foreground">
-							{t('pages.plants.detail.currentStatus.lastWatering.next')}:{' '}
+							{t('features.plants.detail.currentStatus.lastWatering.next')}:{' '}
 							{t('common.tomorrow')}
 						</p>
 					</CardContent>
@@ -226,7 +226,7 @@ export function PlantDetailPage() {
 				<Card>
 					<CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
 						<CardTitle className="text-sm font-medium">
-							{t('pages.plants.detail.currentStatus.lastFertilization.label')}
+							{t('features.plants.detail.currentStatus.lastFertilization.label')}
 						</CardTitle>
 						<FlowerIcon className="h-4 w-4 text-muted-foreground" />
 					</CardHeader>
@@ -246,7 +246,7 @@ export function PlantDetailPage() {
 						</div>
 						<p className="text-xs text-muted-foreground">
 							{t(
-								'pages.plants.detail.currentStatus.lastFertilization.suggested',
+								'features.plants.detail.currentStatus.lastFertilization.suggested',
 							)}
 							: {t('common.today')}
 						</p>
@@ -256,7 +256,7 @@ export function PlantDetailPage() {
 				<Card>
 					<CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
 						<CardTitle className="text-sm font-medium">
-							{t('pages.plants.detail.currentStatus.plantingDate.label')}
+							{t('features.plants.detail.currentStatus.plantingDate.label')}
 						</CardTitle>
 						<CalendarIcon className="h-4 w-4 text-muted-foreground" />
 					</CardHeader>
@@ -266,7 +266,7 @@ export function PlantDetailPage() {
 						</div>
 						{plantAgeText && (
 							<p className="text-xs text-muted-foreground">
-								{t('pages.plants.detail.currentStatus.plantingDate.age')}:{' '}
+								{t('features.plants.detail.currentStatus.plantingDate.age')}:{' '}
 								{plantAgeText}
 							</p>
 						)}
@@ -283,17 +283,17 @@ export function PlantDetailPage() {
 						<CardHeader>
 							<div className="flex items-center justify-between">
 								<CardTitle>
-									{t('pages.plants.detail.sections.personalNotes.title')}
+									{t('features.plants.detail.sections.personalNotes.title')}
 								</CardTitle>
 								<Button variant="ghost" size="sm">
-									{t('pages.plants.detail.sections.personalNotes.edit')}
+									{t('features.plants.detail.sections.personalNotes.edit')}
 								</Button>
 							</div>
 						</CardHeader>
 						<CardContent>
 							<p className="text-muted-foreground whitespace-pre-wrap">
 								{plant.notes ||
-									t('pages.plants.detail.sections.personalNotes.empty')}
+									t('features.plants.detail.sections.personalNotes.empty')}
 							</p>
 						</CardContent>
 					</Card>
@@ -303,7 +303,7 @@ export function PlantDetailPage() {
 						<CardHeader>
 							<div className="flex items-center justify-between">
 								<CardTitle>
-									{t('pages.plants.detail.sections.recentHistory.title')}
+									{t('features.plants.detail.sections.recentHistory.title')}
 								</CardTitle>
 								<Button variant="link" className="h-auto p-0">
 									{t('common.viewAll')}
@@ -316,22 +316,22 @@ export function PlantDetailPage() {
 									<TableRow>
 										<TableHead>
 											{t(
-												'pages.plants.detail.sections.recentHistory.table.date',
+												'features.plants.detail.sections.recentHistory.table.date',
 											)}
 										</TableHead>
 										<TableHead>
 											{t(
-												'pages.plants.detail.sections.recentHistory.table.action',
+												'features.plants.detail.sections.recentHistory.table.action',
 											)}
 										</TableHead>
 										<TableHead>
 											{t(
-												'pages.plants.detail.sections.recentHistory.table.details',
+												'features.plants.detail.sections.recentHistory.table.details',
 											)}
 										</TableHead>
 										<TableHead>
 											{t(
-												'pages.plants.detail.sections.recentHistory.table.status',
+												'features.plants.detail.sections.recentHistory.table.status',
 											)}
 										</TableHead>
 									</TableRow>
@@ -346,14 +346,14 @@ export function PlantDetailPage() {
 												</div>
 												<span>
 													{t(
-														'pages.plants.detail.sections.recentHistory.watering',
+														'features.plants.detail.sections.recentHistory.watering',
 													)}
 												</span>
 											</div>
 										</TableCell>
 										<TableCell>
 											{t(
-												'pages.plants.detail.sections.recentHistory.wateringDetails',
+												'features.plants.detail.sections.recentHistory.wateringDetails',
 											)}
 										</TableCell>
 										<TableCell>
@@ -372,14 +372,14 @@ export function PlantDetailPage() {
 												</div>
 												<span>
 													{t(
-														'pages.plants.detail.sections.recentHistory.pruning',
+														'features.plants.detail.sections.recentHistory.pruning',
 													)}
 												</span>
 											</div>
 										</TableCell>
 										<TableCell>
 											{t(
-												'pages.plants.detail.sections.recentHistory.pruningDetails',
+												'features.plants.detail.sections.recentHistory.pruningDetails',
 											)}
 										</TableCell>
 										<TableCell>
@@ -398,14 +398,14 @@ export function PlantDetailPage() {
 												</div>
 												<span>
 													{t(
-														'pages.plants.detail.sections.recentHistory.fertilization',
+														'features.plants.detail.sections.recentHistory.fertilization',
 													)}
 												</span>
 											</div>
 										</TableCell>
 										<TableCell>
 											{t(
-												'pages.plants.detail.sections.recentHistory.fertilizationDetails',
+												'features.plants.detail.sections.recentHistory.fertilizationDetails',
 											)}
 										</TableCell>
 										<TableCell>
@@ -425,7 +425,7 @@ export function PlantDetailPage() {
 						<CardHeader>
 							<div className="flex items-center justify-between">
 								<CardTitle>
-									{t('pages.plants.detail.sections.progressGallery.title')}
+									{t('features.plants.detail.sections.progressGallery.title')}
 								</CardTitle>
 								<Button variant="ghost" size="icon">
 									<FlowerIcon className="h-4 w-4" />
@@ -442,7 +442,7 @@ export function PlantDetailPage() {
 										{i === 4 ? (
 											<span className="text-xs text-muted-foreground">
 												+12{' '}
-												{t('pages.plants.detail.sections.progressGallery.more')}
+												{t('features.plants.detail.sections.progressGallery.more')}
 											</span>
 										) : (
 											<FlowerIcon className="h-8 w-8 text-muted-foreground" />
@@ -460,7 +460,7 @@ export function PlantDetailPage() {
 					<Card>
 						<CardHeader>
 							<CardTitle>
-								{t('pages.plants.detail.sections.upcomingCare.title')}
+								{t('features.plants.detail.sections.upcomingCare.title')}
 							</CardTitle>
 						</CardHeader>
 						<CardContent className="px-6 pb-6">
@@ -477,21 +477,21 @@ export function PlantDetailPage() {
 							<div className="flex items-center gap-2">
 								<FlowerIcon className="h-5 w-5 text-green-600" />
 								<CardTitle className="text-green-900">
-									{t('pages.plants.detail.sections.wiki.title')}
+									{t('features.plants.detail.sections.wiki.title')}
 								</CardTitle>
 							</div>
 						</CardHeader>
 						<CardContent>
 							<p className="text-sm text-green-800 mb-2">
 								<strong>
-									{t('pages.plants.detail.sections.wiki.didYouKnow')}
+									{t('features.plants.detail.sections.wiki.didYouKnow')}
 								</strong>
 							</p>
 							<p className="text-green-700 mb-4">
-								{t('pages.plants.detail.sections.wiki.description')}
+								{t('features.plants.detail.sections.wiki.description')}
 							</p>
 							<Button variant="link" className="p-0 text-green-600">
-								{t('pages.plants.detail.sections.wiki.readMore')} →
+								{t('features.plants.detail.sections.wiki.readMore')} →
 							</Button>
 						</CardContent>
 					</Card>

--- a/apps/web/features/plants/components/pages/plants-page.tsx
+++ b/apps/web/features/plants/components/pages/plants-page.tsx
@@ -56,25 +56,25 @@ export function PlantsPage() {
 	} = usePlantsPage();
 
 	const filterOptions: FilterOption[] = [
-		{ value: 'all', label: t('pages.plants.list.filters.all') },
+		{ value: 'all', label: t('features.plants.list.filters.all') },
 		{
 			value: 'indoor',
-			label: t('pages.plants.list.filters.indoor'),
+			label: t('features.plants.list.filters.indoor'),
 			icon: HomeIcon,
 		},
 		{
 			value: 'outdoor',
-			label: t('pages.plants.list.filters.outdoor'),
+			label: t('features.plants.list.filters.outdoor'),
 			icon: Building2Icon,
 		},
 		{
 			value: 'needsWater',
-			label: t('pages.plants.list.filters.needsWater'),
+			label: t('features.plants.list.filters.needsWater'),
 			icon: DropletsIcon,
 		},
 		{
 			value: 'healthy',
-			label: t('pages.plants.list.filters.healthy'),
+			label: t('features.plants.list.filters.healthy'),
 			icon: CheckCircleIcon,
 		},
 	];
@@ -83,19 +83,19 @@ export function PlantsPage() {
 		<div className="mx-auto space-y-6">
 			{/* Header */}
 			<PageHeader
-				title={t('pages.plants.list.title')}
-				description={t('pages.plants.list.description')}
+				title={t('features.plants.list.title')}
+				description={t('features.plants.list.description')}
 				actions={[
 					<Button key="create" onClick={handleAddClick}>
 						<PlusIcon className="mr-2 h-4 w-4" />
-						{t('pages.plants.list.actions.create.button')}
+						{t('features.plants.list.actions.create.button')}
 					</Button>,
 				]}
 			/>
 
 			{/* Search and Filters */}
 			<SearchAndFilters
-				searchPlaceholder={t('pages.plants.list.search.placeholder')}
+				searchPlaceholder={t('features.plants.list.search.placeholder')}
 				searchValue={searchQuery}
 				onSearchChange={setSearchQuery}
 				filterOptions={filterOptions}
@@ -116,7 +116,7 @@ export function PlantsPage() {
 				) : error ? (
 					<div className="flex items-center justify-center min-h-[400px]">
 						<p className="text-destructive">
-							{t('pages.plants.list.error.loading', {
+							{t('features.plants.list.error.loading', {
 								message: (error as Error).message,
 							})}
 						</p>
@@ -128,19 +128,19 @@ export function PlantsPage() {
 								<TableRow>
 									<TableHead className="w-[80px]">IMG</TableHead>
 									<TableHead>
-										{t('pages.plants.list.table.columns.plant')}
+										{t('features.plants.list.table.columns.plant')}
 									</TableHead>
 									<TableHead>
-										{t('pages.plants.list.table.columns.location')}
+										{t('features.plants.list.table.columns.location')}
 									</TableHead>
 									<TableHead>
-										{t('pages.plants.list.table.columns.status')}
+										{t('features.plants.list.table.columns.status')}
 									</TableHead>
 									<TableHead>
-										{t('pages.plants.list.table.columns.lastWatering')}
+										{t('features.plants.list.table.columns.lastWatering')}
 									</TableHead>
 									<TableHead className="w-[80px]">
-										{t('pages.plants.list.table.columns.actions')}
+										{t('features.plants.list.table.columns.actions')}
 									</TableHead>
 								</TableRow>
 							</TableHeader>
@@ -160,8 +160,8 @@ export function PlantsPage() {
 					<div className="flex items-center justify-center min-h-[400px]">
 						<p className="text-muted-foreground">
 							{hasAnyPlants
-								? t('pages.plants.list.empty.filtered')
-								: t('pages.plants.list.empty')}
+								? t('features.plants.list.empty.filtered')
+								: t('features.plants.list.empty')}
 						</p>
 					</div>
 				)}

--- a/apps/web/features/plants/hooks/use-plant-detail-page/use-plant-detail-page.ts
+++ b/apps/web/features/plants/hooks/use-plant-detail-page/use-plant-detail-page.ts
@@ -104,16 +104,16 @@ export function usePlantDetailPage(id: string) {
 		if (!plantAge) return null;
 		switch (plantAge.type) {
 			case 'yearsMonths':
-				return t('pages.plants.detail.age.yearsMonths', {
+				return t('features.plants.detail.age.yearsMonths', {
 					years: plantAge.years,
 					months: plantAge.months,
 				});
 			case 'years':
-				return t('pages.plants.detail.age.years', { years: plantAge.years });
+				return t('features.plants.detail.age.years', { years: plantAge.years });
 			case 'months':
-				return t('pages.plants.detail.age.months', { months: plantAge.months });
+				return t('features.plants.detail.age.months', { months: plantAge.months });
 			case 'days':
-				return t('pages.plants.detail.age.days', { days: plantAge.days });
+				return t('features.plants.detail.age.days', { days: plantAge.days });
 			default:
 				return null;
 		}
@@ -135,35 +135,35 @@ export function usePlantDetailPage(id: string) {
 		return [
 			{
 				id: 'tomorrow',
-				label: t('pages.plants.detail.sections.upcomingCare.tomorrow'),
+				label: t('features.plants.detail.sections.upcomingCare.tomorrow'),
 				isActive: true,
 				items: [
 					{
 						id: 'tomorrow-watering',
-						title: t('pages.plants.detail.sections.upcomingCare.lightWatering'),
+						title: t('features.plants.detail.sections.upcomingCare.lightWatering'),
 						subtitle: '10:00 AM',
 					},
 				],
 			},
 			{
 				id: 'in5days',
-				label: t('pages.plants.detail.sections.upcomingCare.in5Days'),
+				label: t('features.plants.detail.sections.upcomingCare.in5Days'),
 				items: [
 					{
 						id: 'in5days-cleaning',
-						title: t('pages.plants.detail.sections.upcomingCare.cleanLeaves'),
-						subtitle: t('pages.plants.detail.sections.upcomingCare.duringDay'),
+						title: t('features.plants.detail.sections.upcomingCare.cleanLeaves'),
+						subtitle: t('features.plants.detail.sections.upcomingCare.duringDay'),
 					},
 				],
 			},
 			{
 				id: 'in2weeks',
-				label: t('pages.plants.detail.sections.upcomingCare.in2Weeks'),
+				label: t('features.plants.detail.sections.upcomingCare.in2Weeks'),
 				items: [
 					{
 						id: 'in2weeks-fertilization',
-						title: t('pages.plants.detail.sections.upcomingCare.fertilization'),
-						subtitle: t('pages.plants.detail.sections.upcomingCare.spring'),
+						title: t('features.plants.detail.sections.upcomingCare.fertilization'),
+						subtitle: t('features.plants.detail.sections.upcomingCare.spring'),
 					},
 				],
 			},

--- a/apps/web/features/plants/hooks/use-plant-transplant-form/use-plant-transplant-form.ts
+++ b/apps/web/features/plants/hooks/use-plant-transplant-form/use-plant-transplant-form.ts
@@ -9,7 +9,7 @@ const createPlantTransplantSchema = (translations: (key: string) => string) =>
 	z.object({
 		targetGrowingUnitId: z.string().min(1, {
 			message: translations(
-				'pages.plants.detail.modals.transplant.fields.targetGrowingUnitId.required',
+				'features.plants.detail.modals.transplant.fields.targetGrowingUnitId.required',
 			),
 		}),
 	});

--- a/apps/web/features/plants/locales/en.json
+++ b/apps/web/features/plants/locales/en.json
@@ -1,0 +1,248 @@
+{
+  "list": {
+    "title": "Plant List",
+    "description": "Manage your botanical collection and monitor its health",
+    "empty": "No plants registered",
+    "emptyFiltered": "No plants match the current filters",
+    "search": {
+      "placeholder": "Search by name, species or location..."
+    },
+    "filters": {
+      "all": "All",
+      "indoor": "Indoor",
+      "outdoor": "Outdoor",
+      "needsWater": "Needs Water",
+      "healthy": "Healthy"
+    },
+    "table": {
+      "columns": {
+        "plant": "PLANT / SPECIES",
+        "location": "LOCATION",
+        "status": "STATUS",
+        "lastWatering": "LAST WATERING",
+        "actions": "ACTIONS"
+      },
+      "lastWatering": {
+        "today": "Today",
+        "yesterday": "Yesterday",
+        "daysAgo": "{days} days ago",
+        "weeksAgo": "{weeks} weeks ago"
+      },
+      "pagination": {
+        "showing": "Showing {from} to {to} of {total} plants"
+      }
+    },
+    "actions": {
+      "create": {
+        "button": "Add Plant",
+        "title": "Create Plant",
+        "description": "Add a new plant to your collection",
+        "submit": "Create",
+        "loading": "Creating..."
+      },
+      "view": "View",
+      "edit": "Edit",
+      "delete": "Delete"
+    },
+    "error": {
+      "loading": "Error loading plants: {message}"
+    },
+    "growingUnit": {
+      "plantCount": "{count} of {total} plants"
+    }
+  },
+  "detail": {
+    "title": "Plant Detail",
+    "notFound": "Plant not found",
+    "unnamed": "Unnamed plant",
+    "error": {
+      "loading": "Error loading plant: {message}"
+    },
+    "fields": {
+      "name": {
+        "label": "Name",
+        "placeholder": "Plant name"
+      },
+      "species": {
+        "label": "Species",
+        "placeholder": "Plant species"
+      },
+      "plantedDate": {
+        "label": "Planted Date"
+      },
+      "notes": {
+        "label": "Notes",
+        "placeholder": "Additional notes about the plant"
+      },
+      "growingUnitId": {
+        "label": "Growing Unit",
+        "placeholder": "Select a growing unit"
+      }
+    },
+    "location": {
+      "indoor": "INDOOR",
+      "outdoor": "OUTDOOR"
+    },
+    "actions": {
+      "editDetails": "Edit Details",
+      "registerWatering": "Register Watering",
+      "fertilize": "Fertilize",
+      "transplant": "Transplant"
+    },
+    "metrics": {
+      "title": "Care Requirements",
+      "watering": {
+        "label": "WATERING",
+        "every7Days": "Every 7 days"
+      },
+      "light": {
+        "label": "LIGHT",
+        "indirect": "Indirect"
+      },
+      "temperature": {
+        "label": "TEMP"
+      },
+      "humidity": {
+        "label": "HUMIDITY",
+        "high": "High"
+      }
+    },
+    "currentStatus": {
+      "lastWatering": {
+        "label": "Last Watering",
+        "onTime": "On time",
+        "daysAgo": "Days ago",
+        "next": "Next",
+        "tomorrow": "Tomorrow"
+      },
+      "lastFertilization": {
+        "label": "Last Fertilization",
+        "pending": "Pending",
+        "monthAgo": "{months} month ago",
+        "suggested": "Suggested",
+        "today": "Today"
+      },
+      "plantingDate": {
+        "label": "Planting Date",
+        "age": "Age"
+      }
+    },
+    "age": {
+      "yearsMonths": "{years} year {months} months",
+      "years": "{years} year",
+      "months": "{months} months",
+      "days": "{days} days"
+    },
+    "sections": {
+      "personalNotes": {
+        "title": "Personal Notes",
+        "edit": "Edit Notes",
+        "empty": "No personal notes yet. Add some notes about your plant care routine!"
+      },
+      "upcomingCare": {
+        "title": "Upcoming Care",
+        "tomorrow": "TOMORROW",
+        "lightWatering": "Light Watering",
+        "in5Days": "IN 5 DAYS",
+        "cleanLeaves": "Clean Leaves",
+        "duringDay": "During the day",
+        "in2Weeks": "IN 2 WEEKS",
+        "fertilization": "Fertilization",
+        "spring": "Spring"
+      },
+      "recentHistory": {
+        "title": "Recent History",
+        "viewAll": "View all",
+        "today": "Today",
+        "watering": "Watering",
+        "wateringDetails": "250ml filtered water",
+        "pruning": "Pruning",
+        "pruningDetails": "Lower yellow leaves",
+        "fertilization": "Fertilization",
+        "fertilizationDetails": "Liquid fertilizer NPK 20-20-20",
+        "completed": "Completed",
+        "table": {
+          "date": "DATE",
+          "action": "ACTION",
+          "details": "DETAILS",
+          "status": "STATUS"
+        }
+      },
+      "progressGallery": {
+        "title": "Progress Gallery",
+        "more": "more"
+      },
+      "wiki": {
+        "title": "Plant Wiki",
+        "didYouKnow": "Did you know...",
+        "description": "Monstera Deliciosa is also known as 'Adam's Rib' due to the unique shape of its leaves that develop natural holes (fenestrations) as they mature.",
+        "readMore": "READ MORE"
+      }
+    },
+    "modals": {
+      "transplant": {
+        "title": "Transplant Plant",
+        "description": "Move this plant to a different growing unit",
+        "fields": {
+          "sourceGrowingUnit": {
+            "label": "From",
+            "unknown": "Unknown growing unit",
+            "helper": "Current growing unit (cannot be changed)"
+          },
+          "targetGrowingUnitId": {
+            "label": "To",
+            "placeholder": "Select a target growing unit",
+            "required": "You must select a target growing unit",
+            "capacityAvailable": "spaces available"
+          }
+        },
+        "actions": {
+          "submit": {
+            "label": "Transplant",
+            "loading": "Transplanting..."
+          }
+        }
+      },
+      "editDetails": {
+        "title": "Edit Plant Details",
+        "description": "Update the information for this plant",
+        "actions": {
+          "submit": {
+            "label": "Save Changes",
+            "loading": "Saving..."
+          }
+        }
+      }
+    },
+    "image": {
+      "placeholder": "Plant image placeholder"
+    }
+  },
+  "status": {
+    "PLANTED": "Planted",
+    "GROWING": "Growing",
+    "HARVESTED": "Harvested",
+    "DEAD": "Dead",
+    "ARCHIVED": "Archived"
+  },
+  "validation": {
+    "id": {
+      "required": "ID is required"
+    },
+    "plantId": {
+      "required": "Plant ID is required"
+    },
+    "species": {
+      "required": "Species is required"
+    },
+    "status": {
+      "invalid": "Invalid status"
+    },
+    "sourceGrowingUnitId": {
+      "required": "Source growing unit ID is required"
+    },
+    "targetGrowingUnitId": {
+      "required": "Target growing unit ID is required"
+    }
+  }
+}

--- a/apps/web/features/plants/locales/es.json
+++ b/apps/web/features/plants/locales/es.json
@@ -1,0 +1,248 @@
+{
+  "list": {
+    "title": "Lista de Plantas",
+    "description": "Gestiona tu colección botánica y monitorea su salud",
+    "empty": "No hay plantas registradas",
+    "emptyFiltered": "No hay plantas que coincidan con los filtros actuales",
+    "search": {
+      "placeholder": "Buscar por nombre, especie o ubicación..."
+    },
+    "filters": {
+      "all": "Todas",
+      "indoor": "Interior",
+      "outdoor": "Exterior",
+      "needsWater": "Necesita Agua",
+      "healthy": "Saludables"
+    },
+    "table": {
+      "columns": {
+        "plant": "PLANTA / ESPECIE",
+        "location": "UBICACIÓN",
+        "status": "ESTADO",
+        "lastWatering": "ÚLTIMO RIEGO",
+        "actions": "ACCIONES"
+      },
+      "lastWatering": {
+        "today": "Hoy",
+        "yesterday": "Ayer",
+        "daysAgo": "Hace {days} días",
+        "weeksAgo": "Hace {weeks} semanas"
+      },
+      "pagination": {
+        "showing": "Mostrando {from} a {to} de {total} plantas"
+      }
+    },
+    "actions": {
+      "create": {
+        "button": "Añadir Planta",
+        "title": "Crear Planta",
+        "description": "Agrega una nueva planta a tu colección",
+        "submit": "Crear",
+        "loading": "Creando..."
+      },
+      "view": "Ver",
+      "edit": "Editar",
+      "delete": "Eliminar"
+    },
+    "error": {
+      "loading": "Error al cargar plantas: {message}"
+    },
+    "growingUnit": {
+      "plantCount": "{count} de {total} plantas"
+    }
+  },
+  "detail": {
+    "title": "Detalle de Planta",
+    "notFound": "Planta no encontrada",
+    "unnamed": "Planta sin nombre",
+    "error": {
+      "loading": "Error al cargar planta: {message}"
+    },
+    "fields": {
+      "name": {
+        "label": "Nombre",
+        "placeholder": "Nombre de la planta"
+      },
+      "species": {
+        "label": "Especie",
+        "placeholder": "Especie de la planta"
+      },
+      "plantedDate": {
+        "label": "Fecha de plantación"
+      },
+      "notes": {
+        "label": "Notas",
+        "placeholder": "Notas adicionales sobre la planta"
+      },
+      "growingUnitId": {
+        "label": "Unidad de Cultivo",
+        "placeholder": "Selecciona una unidad de cultivo"
+      }
+    },
+    "location": {
+      "indoor": "INTERIOR",
+      "outdoor": "EXTERIOR"
+    },
+    "actions": {
+      "editDetails": "Editar Detalles",
+      "registerWatering": "Registrar Riego",
+      "fertilize": "Fertilizar",
+      "transplant": "Trasplantar"
+    },
+    "metrics": {
+      "title": "Requisitos de Cuidado",
+      "watering": {
+        "label": "RIEGO",
+        "every7Days": "Cada 7 días"
+      },
+      "light": {
+        "label": "LUZ",
+        "indirect": "Indirecta"
+      },
+      "temperature": {
+        "label": "TEMP"
+      },
+      "humidity": {
+        "label": "HUMEDAD",
+        "high": "Alta"
+      }
+    },
+    "currentStatus": {
+      "lastWatering": {
+        "label": "Último Riego",
+        "onTime": "A tiempo",
+        "daysAgo": "Hace {days} días",
+        "next": "Próximo",
+        "tomorrow": "Mañana"
+      },
+      "lastFertilization": {
+        "label": "Última Fertilización",
+        "pending": "Pendiente",
+        "monthAgo": "Hace {months} mes{months, plural, =1 {} other {es}}",
+        "suggested": "Sugerido",
+        "today": "Hoy"
+      },
+      "plantingDate": {
+        "label": "Fecha de Plantación",
+        "age": "Edad"
+      }
+    },
+    "age": {
+      "yearsMonths": "{years} año {months} meses",
+      "years": "{years} año",
+      "months": "{months} meses",
+      "days": "{days} días"
+    },
+    "sections": {
+      "personalNotes": {
+        "title": "Notas Personales",
+        "edit": "Editar Notas",
+        "empty": "Aún no hay notas personales. ¡Agrega algunas notas sobre tu rutina de cuidado de plantas!"
+      },
+      "upcomingCare": {
+        "title": "Próximos Cuidados",
+        "tomorrow": "MAÑANA",
+        "lightWatering": "Riego Ligero",
+        "in5Days": "EN 5 DÍAS",
+        "cleanLeaves": "Limpiar Hojas",
+        "duringDay": "Durante el día",
+        "in2Weeks": "EN 2 SEMANAS",
+        "fertilization": "Fertilización",
+        "spring": "Primavera"
+      },
+      "recentHistory": {
+        "title": "Historial Reciente",
+        "viewAll": "Ver todo",
+        "today": "Hoy",
+        "watering": "Riego",
+        "wateringDetails": "250ml de agua filtrada",
+        "pruning": "Poda",
+        "pruningDetails": "Hojas amarillas inferiores",
+        "fertilization": "Fertilización",
+        "fertilizationDetails": "Fertilizante líquido NPK 20-20-20",
+        "completed": "Completado",
+        "table": {
+          "date": "FECHA",
+          "action": "ACCIÓN",
+          "details": "DETALLES",
+          "status": "ESTADO"
+        }
+      },
+      "progressGallery": {
+        "title": "Galería de Progreso",
+        "more": "más"
+      },
+      "wiki": {
+        "title": "Wiki Planta",
+        "didYouKnow": "Sabías que...",
+        "description": "La Monstera Deliciosa también es conocida como 'Costilla de Adán' debido a la forma única de sus hojas que desarrollan agujeros naturales (fenestraciones) a medida que maduran.",
+        "readMore": "LEER MÁS"
+      }
+    },
+    "modals": {
+      "transplant": {
+        "title": "Trasplantar Planta",
+        "description": "Mueve esta planta a una unidad de cultivo diferente",
+        "fields": {
+          "sourceGrowingUnit": {
+            "label": "Desde",
+            "unknown": "Unidad de cultivo desconocida",
+            "helper": "Unidad de cultivo actual (no se puede cambiar)"
+          },
+          "targetGrowingUnitId": {
+            "label": "Hacia",
+            "placeholder": "Selecciona una unidad de cultivo destino",
+            "required": "Debes seleccionar una unidad de cultivo destino",
+            "capacityAvailable": "espacios disponibles"
+          }
+        },
+        "actions": {
+          "submit": {
+            "label": "Trasplantar",
+            "loading": "Trasplantando..."
+          }
+        }
+      },
+      "editDetails": {
+        "title": "Editar Detalles de la Planta",
+        "description": "Actualiza la información de esta planta",
+        "actions": {
+          "submit": {
+            "label": "Guardar Cambios",
+            "loading": "Guardando..."
+          }
+        }
+      }
+    },
+    "image": {
+      "placeholder": "Imagen de la planta"
+    }
+  },
+  "status": {
+    "PLANTED": "Plantada",
+    "GROWING": "Creciendo",
+    "HARVESTED": "Cosechada",
+    "DEAD": "Muerta",
+    "ARCHIVED": "Archivada"
+  },
+  "validation": {
+    "id": {
+      "required": "El ID es requerido"
+    },
+    "plantId": {
+      "required": "El ID de la planta es requerido"
+    },
+    "species": {
+      "required": "La especie es requerida"
+    },
+    "status": {
+      "invalid": "Estado inválido"
+    },
+    "sourceGrowingUnitId": {
+      "required": "El ID de la unidad de cultivo origen es requerido"
+    },
+    "targetGrowingUnitId": {
+      "required": "El ID de la unidad de cultivo destino es requerido"
+    }
+  }
+}

--- a/apps/web/features/users/components/organisms/user-profile-account-section/user-profile-account-section.tsx
+++ b/apps/web/features/users/components/organisms/user-profile-account-section/user-profile-account-section.tsx
@@ -42,17 +42,17 @@ export function UserProfileAccountSection({
 			<CardHeader>
 				<CardTitle className="flex items-center gap-2">
 					<Calendar className="size-5" />
-					{t('pages.user.profile.sections.accountInfo.title')}
+					{t('features.users.profile.sections.accountInfo.title')}
 				</CardTitle>
 				<CardDescription>
-					{t('pages.user.profile.sections.accountInfo.description')}
+					{t('features.users.profile.sections.accountInfo.description')}
 				</CardDescription>
 			</CardHeader>
 			<CardContent className="space-y-4">
 				{profile.role && (
 					<div className="space-y-1">
 						<p className="text-sm font-medium text-muted-foreground">
-							{t('pages.user.profile.fields.role.label')}
+							{t('features.users.profile.fields.role.label')}
 						</p>
 						<p className="text-sm">{profile.role}</p>
 					</div>
@@ -63,7 +63,7 @@ export function UserProfileAccountSection({
 				{profile.status && (
 					<div className="space-y-1">
 						<p className="text-sm font-medium text-muted-foreground">
-							{t('pages.user.profile.fields.status.label')}
+							{t('features.users.profile.fields.status.label')}
 						</p>
 						<p className="text-sm">{profile.status}</p>
 					</div>
@@ -76,7 +76,7 @@ export function UserProfileAccountSection({
 						<div className="flex items-center gap-2">
 							<Calendar className="size-4 text-muted-foreground" />
 							<p className="text-sm font-medium text-muted-foreground">
-								{t('pages.user.profile.fields.createdAt')}
+								{t('features.users.profile.fields.createdAt')}
 							</p>
 						</div>
 						<p className="text-sm">{formatDate(profile.createdAt)}</p>
@@ -90,7 +90,7 @@ export function UserProfileAccountSection({
 						<div className="flex items-center gap-2">
 							<Clock className="size-4 text-muted-foreground" />
 							<p className="text-sm font-medium text-muted-foreground">
-								{t('pages.user.profile.fields.lastLoginAt')}
+								{t('features.users.profile.fields.lastLoginAt')}
 							</p>
 						</div>
 						<p className="text-sm">{formatDate(profile.lastLoginAt)}</p>

--- a/apps/web/features/users/components/organisms/user-profile-auth-section/user-profile-auth-section.tsx
+++ b/apps/web/features/users/components/organisms/user-profile-auth-section/user-profile-auth-section.tsx
@@ -35,10 +35,10 @@ export function UserProfileAuthSection({
 			<CardHeader>
 				<CardTitle className="flex items-center gap-2">
 					<Shield className="size-5" />
-					{t('pages.user.profile.sections.authInfo.title')}
+					{t('features.users.profile.sections.authInfo.title')}
 				</CardTitle>
 				<CardDescription>
-					{t('pages.user.profile.sections.authInfo.description')}
+					{t('features.users.profile.sections.authInfo.description')}
 				</CardDescription>
 			</CardHeader>
 			<CardContent className="space-y-4">
@@ -47,7 +47,7 @@ export function UserProfileAuthSection({
 						<div className="flex items-center gap-2">
 							<Mail className="size-4 text-muted-foreground" />
 							<p className="text-sm font-medium text-muted-foreground">
-								{t('pages.user.profile.fields.email')}
+								{t('features.users.profile.fields.email')}
 							</p>
 						</div>
 						<div className="flex items-center gap-2">
@@ -60,12 +60,12 @@ export function UserProfileAuthSection({
 									{profile.emailVerified ? (
 										<>
 											<CheckCircle2 className="size-3" />
-											{t('pages.user.profile.fields.verified')}
+											{t('features.users.profile.fields.verified')}
 										</>
 									) : (
 										<>
 											<XCircle className="size-3" />
-											{t('pages.user.profile.fields.unverified')}
+											{t('features.users.profile.fields.unverified')}
 										</>
 									)}
 								</Badge>
@@ -79,7 +79,7 @@ export function UserProfileAuthSection({
 				{profile.provider && (
 					<div className="space-y-1">
 						<p className="text-sm font-medium text-muted-foreground">
-							{t('pages.user.profile.fields.provider')}
+							{t('features.users.profile.fields.provider')}
 						</p>
 						<Badge variant="secondary">{profile.provider}</Badge>
 					</div>

--- a/apps/web/features/users/components/organisms/user-profile-contact-section/user-profile-contact-section.tsx
+++ b/apps/web/features/users/components/organisms/user-profile-contact-section/user-profile-contact-section.tsx
@@ -27,16 +27,16 @@ export function UserProfileContactSection({
 			<CardHeader>
 				<CardTitle className="flex items-center gap-2">
 					<Phone className="size-5" />
-					{t('pages.user.profile.sections.contactInfo.title')}
+					{t('features.users.profile.sections.contactInfo.title')}
 				</CardTitle>
 				<CardDescription>
-					{t('pages.user.profile.sections.contactInfo.description')}
+					{t('features.users.profile.sections.contactInfo.description')}
 				</CardDescription>
 			</CardHeader>
 			<CardContent>
 				<div className="space-y-1">
 					<p className="text-sm font-medium text-muted-foreground">
-						{t('pages.user.profile.fields.phoneNumber')}
+						{t('features.users.profile.fields.phoneNumber')}
 					</p>
 					<p className="text-sm">{profile.phoneNumber}</p>
 				</div>

--- a/apps/web/features/users/components/organisms/user-profile-header/user-profile-header.tsx
+++ b/apps/web/features/users/components/organisms/user-profile-header/user-profile-header.tsx
@@ -20,7 +20,7 @@ export function UserProfileHeader({ profile }: UserProfileHeaderProps) {
 	const fullName =
 		[profile.name, profile.lastName].filter(Boolean).join(' ') ||
 		profile.userName ||
-		t('pages.user.profile.anonymous');
+		t('features.users.profile.anonymous');
 
 	const initials =
 		[profile.name, profile.lastName]

--- a/apps/web/features/users/components/organisms/user-profile-info-section/user-profile-info-section.tsx
+++ b/apps/web/features/users/components/organisms/user-profile-info-section/user-profile-info-section.tsx
@@ -44,27 +44,27 @@ export function UserProfileInfoSection({
 		<Card>
 			<CardHeader>
 				<CardTitle>
-					{t('pages.user.profile.sections.personalInfo.title')}
+					{t('features.users.profile.sections.personalInfo.title')}
 				</CardTitle>
 				<CardDescription>
-					{t('pages.user.profile.sections.personalInfo.description')}
+					{t('features.users.profile.sections.personalInfo.description')}
 				</CardDescription>
 			</CardHeader>
 			<CardContent className="space-y-4">
 				<InfoItem
-					label={t('pages.user.profile.fields.name.label')}
+					label={t('features.users.profile.fields.name.label')}
 					value={profile.name}
 				/>
 				{profile.name && profile.lastName && <Separator />}
 				<InfoItem
-					label={t('pages.user.profile.fields.lastName.label')}
+					label={t('features.users.profile.fields.lastName.label')}
 					value={profile.lastName}
 				/>
 				{(profile.name || profile.lastName) && profile.userName && (
 					<Separator />
 				)}
 				<InfoItem
-					label={t('pages.user.profile.fields.userName.label')}
+					label={t('features.users.profile.fields.userName.label')}
 					value={profile.userName}
 				/>
 			</CardContent>

--- a/apps/web/features/users/components/organisms/user-update-form/user-update-form.tsx
+++ b/apps/web/features/users/components/organisms/user-update-form/user-update-form.tsx
@@ -57,10 +57,10 @@ export function UserUpdateForm({
 		<Form errors={formErrors}>
 			<form onSubmit={handleSubmit} className="space-y-4">
 				<FormItem>
-					<FormLabel>{t('pages.user.profile.fields.name.label')}</FormLabel>
+					<FormLabel>{t('features.users.profile.fields.name.label')}</FormLabel>
 					<FormControl>
 						<Input
-							placeholder={t('pages.user.profile.fields.name.placeholder')}
+							placeholder={t('features.users.profile.fields.name.placeholder')}
 							disabled={isLoading}
 							value={name}
 							onChange={(e) => setName(e.target.value)}
@@ -70,10 +70,10 @@ export function UserUpdateForm({
 				</FormItem>
 
 				<FormItem>
-					<FormLabel>{t('pages.user.profile.fields.lastName.label')}</FormLabel>
+					<FormLabel>{t('features.users.profile.fields.lastName.label')}</FormLabel>
 					<FormControl>
 						<Input
-							placeholder={t('pages.user.profile.fields.lastName.placeholder')}
+							placeholder={t('features.users.profile.fields.lastName.placeholder')}
 							disabled={isLoading}
 							value={lastName}
 							onChange={(e) => setLastName(e.target.value)}
@@ -83,10 +83,10 @@ export function UserUpdateForm({
 				</FormItem>
 
 				<FormItem>
-					<FormLabel>{t('pages.user.profile.fields.userName.label')}</FormLabel>
+					<FormLabel>{t('features.users.profile.fields.userName.label')}</FormLabel>
 					<FormControl>
 						<Input
-							placeholder={t('pages.user.profile.fields.userName.placeholder')}
+							placeholder={t('features.users.profile.fields.userName.placeholder')}
 							disabled={isLoading}
 							value={userName}
 							onChange={(e) => setUserName(e.target.value)}
@@ -96,10 +96,10 @@ export function UserUpdateForm({
 				</FormItem>
 
 				<FormItem>
-					<FormLabel>{t('pages.user.profile.fields.bio.label')}</FormLabel>
+					<FormLabel>{t('features.users.profile.fields.bio.label')}</FormLabel>
 					<FormControl>
 						<Textarea
-							placeholder={t('pages.user.profile.fields.bio.placeholder')}
+							placeholder={t('features.users.profile.fields.bio.placeholder')}
 							disabled={isLoading}
 							value={bio}
 							onChange={(e) => setBio(e.target.value)}
@@ -110,12 +110,12 @@ export function UserUpdateForm({
 
 				<FormItem>
 					<FormLabel>
-						{t('pages.user.profile.fields.avatarUrl.label')}
+						{t('features.users.profile.fields.avatarUrl.label')}
 					</FormLabel>
 					<FormControl>
 						<Input
 							type="url"
-							placeholder={t('pages.user.profile.fields.avatarUrl.placeholder')}
+							placeholder={t('features.users.profile.fields.avatarUrl.placeholder')}
 							disabled={isLoading}
 							value={avatarUrl}
 							onChange={(e) => setAvatarUrl(e.target.value)}
@@ -131,8 +131,8 @@ export function UserUpdateForm({
 				<div className="flex justify-end pt-2">
 					<Button type="submit" disabled={!isDirty || isSubmitting}>
 						{isSubmitting
-							? t('pages.user.profile.actions.update.loading')
-							: t('pages.user.profile.actions.update.label')}
+							? t('features.users.profile.actions.update.loading')
+							: t('features.users.profile.actions.update.label')}
 					</Button>
 				</div>
 			</form>

--- a/apps/web/features/users/components/pages/user-profile-page.tsx
+++ b/apps/web/features/users/components/pages/user-profile-page.tsx
@@ -55,7 +55,7 @@ export function UserProfilePage() {
 			<div className="mx-auto py-8">
 				<div className="flex items-center justify-center min-h-[400px]">
 					<p className="text-destructive">
-						{t('pages.user.profile.error.loading', {
+						{t('features.users.profile.error.loading', {
 							message: profileError.message,
 						})}
 					</p>
@@ -100,10 +100,10 @@ export function UserProfilePage() {
 				<Card>
 					<CardHeader>
 						<CardTitle>
-							{t('pages.user.profile.sections.editProfile.title')}
+							{t('features.users.profile.sections.editProfile.title')}
 						</CardTitle>
 						<CardDescription>
-							{t('pages.user.profile.sections.editProfile.description')}
+							{t('features.users.profile.sections.editProfile.description')}
 						</CardDescription>
 					</CardHeader>
 					<CardContent>

--- a/apps/web/features/users/locales/en.json
+++ b/apps/web/features/users/locales/en.json
@@ -1,0 +1,77 @@
+{
+  "profile": {
+    "title": "User Profile",
+    "anonymous": "Anonymous user",
+    "error": {
+      "loading": "Error loading user: {message}"
+    },
+    "sections": {
+      "personalInfo": {
+        "title": "Personal Information",
+        "description": "Personal and identification data"
+      },
+      "authInfo": {
+        "title": "Authentication Information",
+        "description": "Security and authentication settings"
+      },
+      "accountInfo": {
+        "title": "Account Information",
+        "description": "Account details and activity"
+      },
+      "contactInfo": {
+        "title": "Contact Information",
+        "description": "Contact and communication data"
+      },
+      "editProfile": {
+        "title": "Edit Profile",
+        "description": "Update your personal information"
+      }
+    },
+    "fields": {
+      "email": "Email",
+      "verified": "Verified",
+      "unverified": "Unverified",
+      "provider": "Authentication provider",
+      "twoFactor": "Two-factor authentication",
+      "enabled": "Enabled",
+      "disabled": "Disabled",
+      "createdAt": "Created at",
+      "lastLoginAt": "Last login",
+      "phoneNumber": "Phone number",
+      "name": {
+        "label": "Name",
+        "placeholder": "Enter your name"
+      },
+      "lastName": {
+        "label": "Last Name",
+        "placeholder": "Enter your last name"
+      },
+      "userName": {
+        "label": "Username",
+        "placeholder": "Enter your username"
+      },
+      "bio": {
+        "label": "Bio",
+        "placeholder": "Write a brief bio about yourself"
+      },
+      "avatarUrl": {
+        "label": "Avatar URL",
+        "placeholder": "https://example.com/avatar.jpg"
+      },
+      "role": {
+        "label": "Role"
+      },
+      "status": {
+        "label": "Status"
+      }
+    },
+    "actions": {
+      "update": {
+        "label": "Update Profile",
+        "loading": "Updating..."
+      }
+    }
+  },
+  "loading": "Loading user...",
+  "notFound": "User not found"
+}

--- a/apps/web/features/users/locales/es.json
+++ b/apps/web/features/users/locales/es.json
@@ -1,0 +1,77 @@
+{
+  "profile": {
+    "title": "Perfil de Usuario",
+    "anonymous": "Usuario anónimo",
+    "error": {
+      "loading": "Error al cargar usuario: {message}"
+    },
+    "sections": {
+      "personalInfo": {
+        "title": "Información Personal",
+        "description": "Datos personales y de identificación"
+      },
+      "authInfo": {
+        "title": "Información de Autenticación",
+        "description": "Configuración de seguridad y autenticación"
+      },
+      "accountInfo": {
+        "title": "Información de Cuenta",
+        "description": "Detalles de la cuenta y actividad"
+      },
+      "contactInfo": {
+        "title": "Información de Contacto",
+        "description": "Datos de contacto y comunicación"
+      },
+      "editProfile": {
+        "title": "Editar Perfil",
+        "description": "Actualiza tu información personal"
+      }
+    },
+    "fields": {
+      "email": "Correo electrónico",
+      "verified": "Verificado",
+      "unverified": "No verificado",
+      "provider": "Proveedor de autenticación",
+      "twoFactor": "Autenticación de dos factores",
+      "enabled": "Habilitado",
+      "disabled": "Deshabilitado",
+      "createdAt": "Fecha de creación",
+      "lastLoginAt": "Último inicio de sesión",
+      "phoneNumber": "Número de teléfono",
+      "name": {
+        "label": "Nombre",
+        "placeholder": "Ingresa tu nombre"
+      },
+      "lastName": {
+        "label": "Apellido",
+        "placeholder": "Ingresa tu apellido"
+      },
+      "userName": {
+        "label": "Nombre de usuario",
+        "placeholder": "Ingresa tu nombre de usuario"
+      },
+      "bio": {
+        "label": "Biografía",
+        "placeholder": "Escribe una breve biografía sobre ti"
+      },
+      "avatarUrl": {
+        "label": "URL del avatar",
+        "placeholder": "https://ejemplo.com/avatar.jpg"
+      },
+      "role": {
+        "label": "Rol"
+      },
+      "status": {
+        "label": "Estado"
+      }
+    },
+    "actions": {
+      "update": {
+        "label": "Actualizar perfil",
+        "loading": "Actualizando..."
+      }
+    }
+  },
+  "loading": "Cargando usuario...",
+  "notFound": "Usuario no encontrado"
+}

--- a/apps/web/shared/i18n/request.ts
+++ b/apps/web/shared/i18n/request.ts
@@ -1,6 +1,38 @@
 import { getRequestConfig } from 'next-intl/server';
 import { routing } from 'shared/i18n/routing';
 
+// Helper to merge translations from multiple sources
+async function loadMessages(locale: string) {
+	const [shared, plants, growingUnits, locations, auth, users, dashboard] =
+		await Promise.all([
+			import(`@/shared/locales/${locale}.json`).then((m) => m.default),
+			import(`@/features/plants/locales/${locale}.json`).then((m) => m.default),
+			import(`@/features/growing-units/locales/${locale}.json`).then(
+				(m) => m.default,
+			),
+			import(`@/features/locations/locales/${locale}.json`).then(
+				(m) => m.default,
+			),
+			import(`@/features/auth/locales/${locale}.json`).then((m) => m.default),
+			import(`@/features/users/locales/${locale}.json`).then((m) => m.default),
+			import(`@/features/dashboard/locales/${locale}.json`).then(
+				(m) => m.default,
+			),
+		]);
+
+	return {
+		...shared,
+		features: {
+			plants,
+			growingUnits,
+			locations,
+			auth,
+			users,
+			dashboard,
+		},
+	};
+}
+
 export default getRequestConfig(async ({ requestLocale }) => {
 	// This typically corresponds to the `[locale]` segment
 	let locale = await requestLocale;
@@ -12,7 +44,7 @@ export default getRequestConfig(async ({ requestLocale }) => {
 
 	return {
 		locale: locale as string,
-		messages: (await import(`@/shared/locales/${locale}.json`)).default,
+		messages: await loadMessages(locale),
 		timeZone: 'Europe/Madrid',
 	};
 });

--- a/apps/web/shared/locales/en.json
+++ b/apps/web/shared/locales/en.json
@@ -1,1401 +1,190 @@
 {
-	"common": {
-		"loading": "Loading...",
-		"error": "Error",
-		"unknown": "Unknown",
-		"cancel": "Cancel",
-		"delete": "Delete",
-		"edit": "Edit",
-		"view": "View",
-		"create": "Create",
-		"update": "Update",
-		"submit": "Submit",
-		"save": "Save",
-		"close": "Close",
-		"back": "Back",
-		"next": "Next",
-		"previous": "Previous",
-		"search": "Search",
-		"filter": "Filter",
-		"all": "All",
-		"none": "None",
-		"empty": "Empty",
-		"notSet": "Not set",
-		"notFound": "Not found",
-		"today": "Today",
-		"yesterday": "Yesterday",
-		"tomorrow": "Tomorrow",
-		"completed": "Completed",
-		"pending": "Pending",
-		"viewAll": "View all",
-		"seeAll": "See all"
-	},
-	"nav": {
-		"home": "Home",
-		"settings": "Settings",
-		"plants": "Plants",
-		"growingUnits": "Growing Units",
-		"locations": "Locations",
-		"search": "Search",
-		"searchPlaceholder": "Search..."
-	},
-	"dashboard": {
-		"page": {
-			"title": "Control Panel",
-			"description": "Welcome back, here's today's summary.",
-			"addPlantButton": "Add Plant"
-		},
-		"error": {
-			"loading": "Error loading dashboard: {message}"
-		},
-		"stats": {
-			"totalPlants": {
-				"title": "Total Plants"
-			},
-			"activeUnits": {
-				"title": "Active Units"
-			},
-			"readyForHarvest": {
-				"title": "Ready for Harvest"
-			},
-			"criticalAlerts": {
-				"title": "Critical Alerts"
-			},
-			"changeSuffix": "vs last month"
-		},
-		"sections": {
-			"plants": {
-				"title": "Plants Overview",
-				"totalPlants": "Total Plants",
-				"activePlants": "Active Plants",
-				"activePercentage": "{percentage}% active",
-				"statusBreakdown": "Status Breakdown",
-				"additionalMetrics": "Additional Metrics",
-				"planted": "Planted",
-				"growing": "Growing",
-				"harvested": "Harvested",
-				"dead": "Dead",
-				"archived": "Archived",
-				"withoutPlantedDate": "Without Planted Date",
-				"withNotes": "With Notes",
-				"recent7Days": "Recent (7 days)"
-			},
-			"capacity": {
-				"title": "Capacity Overview",
-				"averageOccupancy": "Average Occupancy",
-				"totalCapacity": "Total Capacity",
-				"used": "Used",
-				"available": "Available",
-				"atLimit": "At Limit (≥80%)",
-				"full": "Full (100%)"
-			},
-			"growingUnits": {
-				"title": "Growing Units Overview",
-				"totalGrowingUnits": "Total Growing Units",
-				"active": "Active",
-				"empty": "Empty",
-				"byType": "By Type",
-				"percentageOfTotal": "{percentage}% of total",
-				"avgPlantsPerUnit": "Avg Plants/Unit",
-				"min": "Min",
-				"max": "Max",
-				"pots": "Pots",
-				"gardenBeds": "Garden Beds",
-				"hangingBaskets": "Hanging Baskets",
-				"windowBoxes": "Window Boxes"
-			},
-			"growingUnitsStatus": {
-				"title": "Status of Cultivation Units",
-				"empty": "No growing units available"
-			},
-			"recentAlerts": {
-				"title": "Recent Alerts",
-				"empty": "No recent alerts"
-			},
-			"todayTasks": {
-				"title": "Today's Tasks",
-				"assignedTo": "Assigned to",
-				"empty": "No tasks scheduled for today"
-			}
-		},
-		"common": {
-			"retry": "Retry",
-			"active": "active",
-			"total": "total",
-			"growing": "growing",
-			"atLimit": "at limit"
-		}
-	},
-	"shared": {
-		"fields": {
-			"name": {
-				"label": "Name",
-				"placeholder": "Enter name"
-			},
-			"status": {
-				"label": "Status",
-				"placeholder": "Select status"
-			},
-			"createdAt": {
-				"label": "Created at"
-			},
-			"updatedAt": {
-				"label": "Updated at"
-			},
-			"type": {
-				"label": "Type",
-				"placeholder": "Select type"
-			},
-			"locationId": {
-				"label": "Location",
-				"placeholder": "Select a location"
-			},
-			"capacity": {
-				"label": "Capacity",
-				"placeholder": "Number of items"
-			},
-			"remainingCapacity": {
-				"label": "Remaining Capacity"
-			},
-			"volume": {
-				"label": "Volume"
-			},
-			"dimensions": {
-				"label": "Dimensions"
-			},
-			"length": {
-				"label": "Length",
-				"placeholder": "Length"
-			},
-			"width": {
-				"label": "Width",
-				"placeholder": "Width"
-			},
-			"height": {
-				"label": "Height",
-				"placeholder": "Height"
-			},
-			"unit": {
-				"label": "Unit",
-				"placeholder": "Select unit"
-			},
-			"plants": {
-				"label": "Active plants"
-			},
-			"species": {
-				"label": "Species",
-				"placeholder": "Species"
-			},
-			"plantedDate": {
-				"label": "Planting date"
-			},
-			"notes": {
-				"label": "Notes",
-				"placeholder": "Additional notes"
-			},
-			"description": {
-				"label": "Description",
-				"placeholder": "Enter description"
-			},
-			"growingUnitId": {
-				"label": "Growing Unit ID"
-			},
-			"status": {
-				"label": "Status",
-				"placeholder": "Select status"
-			},
-			"createdAt": {
-				"label": "Creation date"
-			},
-			"updatedAt": {
-				"label": "Update date"
-			}
-		},
-		"types": {
-			"growingUnit": {
-				"POT": "Pot",
-				"GARDEN_BED": "Garden bed",
-				"HANGING_BASKET": "Hanging basket",
-				"WINDOW_BOX": "Window box"
-			},
-			"location": {
-				"ROOM": "Room",
-				"BALCONY": "Balcony",
-				"GARDEN": "Garden",
-				"GREENHOUSE": "Greenhouse",
-				"OUTDOOR_SPACE": "Outdoor Space",
-				"INDOOR_SPACE": "Indoor Space"
-			}
-		},
-		"units": {
-			"length": {
-				"MILLIMETER": "Millimeter",
-				"CENTIMETER": "Centimeter",
-				"METER": "Meter",
-				"INCH": "Inch",
-				"FOOT": "Foot"
-			}
-		},
-		"status": {
-			"plant": {
-				"PLANTED": "Planted",
-				"GROWING": "Growing",
-				"HARVESTED": "Harvested",
-				"DEAD": "Dead",
-				"ARCHIVED": "Archived"
-			},
-			"growingUnit": {
-				"active": "ACTIVE",
-				"inactive": "INACTIVE"
-			},
-			"location": {
-				"indoor": "Indoor",
-				"outdoor": "Outdoor"
-			}
-		},
-		"validation": {
-			"required": "This field is required",
-			"invalid": "Invalid value",
-			"id": {
-				"required": "ID is required"
-			},
-			"name": {
-				"required": "Name is required"
-			},
-			"type": {
-				"invalid": "Invalid type"
-			},
-			"locationId": {
-				"required": "Location is required"
-			},
-			"capacity": {
-				"required": "Capacity is required"
-			},
-			"unit": {
-				"invalid": "Invalid unit"
-			}
-		},
-		"pagination": {
-			"info": "Page {page} of {totalPages} ({total} total)",
-			"showing": "Showing {from} to {to} of {total}"
-		},
-		"time": {
-			"daysAgo": "{days} days ago",
-			"weeksAgo": "{weeks} weeks ago",
-			"monthsAgo": "{months} month ago",
-			"yearsAgo": "{years} years ago"
-		}
-	},
-	"pages": {
-		"dashboard": {
-			"title": "Control Panel",
-			"description": "Welcome back, here's today's summary.",
-			"addPlantButton": "Add Plant",
-			"error": {
-				"loading": "Error loading dashboard: {message}"
-			},
-			"stats": {
-				"totalPlants": {
-					"title": "Total Plants"
-				},
-				"activeUnits": {
-					"title": "Active Units"
-				},
-				"readyForHarvest": {
-					"title": "Ready for Harvest"
-				},
-				"criticalAlerts": {
-					"title": "Critical Alerts"
-				},
-				"changeSuffix": "vs last month"
-			},
-			"sections": {
-				"growingUnitsStatus": {
-					"title": "Status of Cultivation Units",
-					"empty": "No growing units available"
-				},
-				"recentAlerts": {
-					"title": "Recent Alerts",
-					"empty": "No recent alerts"
-				},
-				"todayTasks": {
-					"title": "Today's Tasks",
-					"assignedTo": "Assigned to",
-					"empty": "No tasks scheduled for today"
-				}
-			}
-		},
-		"auth": {
-			"title": {
-				"login": "Welcome back",
-				"signup": "Create an account"
-			},
-			"description": {
-				"login": "Enter your email and password to sign in",
-				"signup": "Enter your information to create a new account"
-			},
-			"fields": {
-				"email": {
-					"label": "Email",
-					"placeholder": "name@example.com"
-				},
-				"password": {
-					"label": "Password",
-					"placeholder": {
-						"login": "Enter your password",
-						"signup": "At least 8 characters"
-					}
-				},
-				"confirmPassword": {
-					"label": "Confirm Password",
-					"placeholder": "Confirm your password"
-				}
-			},
-			"actions": {
-				"login": "Sign in",
-				"signup": "Create account",
-				"switchToSignup": "Sign up",
-				"switchToLogin": "Sign in",
-				"loading": {
-					"login": "Signing in...",
-					"signup": "Creating account..."
-				}
-			},
-			"messages": {
-				"switchToSignup": "Don't have an account?",
-				"switchToLogin": "Already have an account?",
-				"error": "An error occurred. Please try again."
-			},
-			"validation": {
-				"email": {
-					"required": "Email is required",
-					"invalid": "Invalid email format"
-				},
-				"password": {
-					"required": "Password is required",
-					"minLength": "Password must be at least 8 characters"
-				},
-				"confirmPassword": {
-					"required": "Please confirm your password",
-					"mismatch": "Passwords don't match"
-				}
-			}
-		},
-		"user": {
-			"profile": {
-				"title": "User Profile",
-				"anonymous": "Anonymous user",
-				"error": {
-					"loading": "Error loading user: {message}"
-				},
-				"sections": {
-					"personalInfo": {
-						"title": "Personal Information",
-						"description": "Personal and identification data"
-					},
-					"authInfo": {
-						"title": "Authentication Information",
-						"description": "Security and authentication settings"
-					},
-					"accountInfo": {
-						"title": "Account Information",
-						"description": "Account details and activity"
-					},
-					"contactInfo": {
-						"title": "Contact Information",
-						"description": "Contact and communication data"
-					},
-					"editProfile": {
-						"title": "Edit Profile",
-						"description": "Update your personal information"
-					}
-				},
-				"fields": {
-					"email": "Email",
-					"verified": "Verified",
-					"unverified": "Unverified",
-					"provider": "Authentication provider",
-					"twoFactor": "Two-factor authentication",
-					"enabled": "Enabled",
-					"disabled": "Disabled",
-					"createdAt": "Created at",
-					"lastLoginAt": "Last login",
-					"phoneNumber": "Phone number",
-					"name": {
-						"label": "Name",
-						"placeholder": "Enter your name"
-					},
-					"lastName": {
-						"label": "Last Name",
-						"placeholder": "Enter your last name"
-					},
-					"userName": {
-						"label": "Username",
-						"placeholder": "Enter your username"
-					},
-					"bio": {
-						"label": "Bio",
-						"placeholder": "Write a brief bio about yourself"
-					},
-					"avatarUrl": {
-						"label": "Avatar URL",
-						"placeholder": "https://example.com/avatar.jpg"
-					},
-					"role": {
-						"label": "Role"
-					},
-					"status": {
-						"label": "Status"
-					}
-				},
-				"actions": {
-					"update": {
-						"label": "Update Profile",
-						"loading": "Updating..."
-					}
-				}
-			}
-		},
-		"plants": {
-			"list": {
-				"title": "Plant List",
-				"description": "Manage your botanical collection and monitor its health",
-				"empty": "No plants registered",
-				"emptyFiltered": "No plants match the current filters",
-				"search": {
-					"placeholder": "Search by name, species or location..."
-				},
-				"filters": {
-					"all": "All",
-					"indoor": "Indoor",
-					"outdoor": "Outdoor",
-					"needsWater": "Needs Water",
-					"healthy": "Healthy"
-				},
-				"table": {
-					"columns": {
-						"plant": "PLANT / SPECIES",
-						"location": "LOCATION",
-						"status": "STATUS",
-						"lastWatering": "LAST WATERING",
-						"actions": "ACTIONS"
-					},
-					"lastWatering": {
-						"today": "Today",
-						"yesterday": "Yesterday",
-						"daysAgo": "{days} days ago",
-						"weeksAgo": "{weeks} weeks ago"
-					}
-				},
-				"actions": {
-					"create": {
-						"button": "Add Plant",
-						"title": "Create Plant",
-						"description": "Add a new plant to your collection",
-						"submit": "Create",
-						"loading": "Creating..."
-					},
-					"view": "View",
-					"edit": "Edit",
-					"delete": "Delete"
-				},
-				"error": {
-					"loading": "Error loading plants: {message}"
-				},
-				"growingUnit": {
-					"plantCount": "{count} of {total} plants"
-				}
-			},
-			"detail": {
-				"title": "Plant Detail",
-				"notFound": "Plant not found",
-				"unnamed": "Unnamed plant",
-				"error": {
-					"loading": "Error loading plant: {message}"
-				},
-				"fields": {
-					"name": {
-						"label": "Name",
-						"placeholder": "Plant name"
-					},
-					"species": {
-						"label": "Species",
-						"placeholder": "Plant species"
-					},
-					"plantedDate": {
-						"label": "Planted Date"
-					},
-					"notes": {
-						"label": "Notes",
-						"placeholder": "Additional notes about the plant"
-					},
-					"growingUnitId": {
-						"label": "Growing Unit",
-						"placeholder": "Select a growing unit"
-					}
-				},
-				"location": {
-					"indoor": "INDOOR",
-					"outdoor": "OUTDOOR"
-				},
-				"actions": {
-					"editDetails": "Edit Details",
-					"registerWatering": "Register Watering",
-					"fertilize": "Fertilize",
-					"transplant": "Transplant"
-				},
-				"metrics": {
-					"title": "Care Requirements",
-					"watering": {
-						"label": "WATERING",
-						"every7Days": "Every 7 days"
-					},
-					"light": {
-						"label": "LIGHT",
-						"indirect": "Indirect"
-					},
-					"temperature": {
-						"label": "TEMP"
-					},
-					"humidity": {
-						"label": "HUMIDITY",
-						"high": "High"
-					}
-				},
-				"currentStatus": {
-					"lastWatering": {
-						"label": "Last Watering",
-						"onTime": "On time",
-						"next": "Next"
-					},
-					"lastFertilization": {
-						"label": "Last Fertilization",
-						"suggested": "Suggested"
-					},
-					"plantingDate": {
-						"label": "Planting Date",
-						"age": "Age"
-					}
-				},
-				"age": {
-					"yearsMonths": "{years} year {months} months",
-					"years": "{years} year",
-					"months": "{months} months",
-					"days": "{days} days"
-				},
-				"sections": {
-					"personalNotes": {
-						"title": "Personal Notes",
-						"edit": "Edit Notes",
-						"empty": "No personal notes yet. Add some notes about your plant care routine!"
-					},
-					"upcomingCare": {
-						"title": "Upcoming Care",
-						"tomorrow": "TOMORROW",
-						"lightWatering": "Light Watering",
-						"in5Days": "IN 5 DAYS",
-						"cleanLeaves": "Clean Leaves",
-						"duringDay": "During the day",
-						"in2Weeks": "IN 2 WEEKS",
-						"fertilization": "Fertilization",
-						"spring": "Spring"
-					},
-					"recentHistory": {
-						"title": "Recent History",
-						"watering": "Watering",
-						"wateringDetails": "250ml filtered water",
-						"pruning": "Pruning",
-						"pruningDetails": "Lower yellow leaves",
-						"fertilization": "Fertilization",
-						"fertilizationDetails": "Liquid fertilizer NPK 20-20-20",
-						"table": {
-							"date": "DATE",
-							"action": "ACTION",
-							"details": "DETAILS",
-							"status": "STATUS"
-						}
-					},
-					"progressGallery": {
-						"title": "Progress Gallery",
-						"more": "more"
-					},
-					"wiki": {
-						"title": "Plant Wiki",
-						"didYouKnow": "Did you know...",
-						"description": "Monstera Deliciosa is also known as 'Adam's Rib' due to the unique shape of its leaves that develop natural holes (fenestrations) as they mature.",
-						"readMore": "READ MORE"
-					}
-				},
-				"modals": {
-					"transplant": {
-						"title": "Transplant Plant",
-						"description": "Move this plant to a different growing unit",
-						"fields": {
-							"sourceGrowingUnit": {
-								"label": "From",
-								"unknown": "Unknown growing unit",
-								"helper": "Current growing unit (cannot be changed)"
-							},
-							"targetGrowingUnitId": {
-								"label": "To",
-								"placeholder": "Select a target growing unit",
-								"required": "You must select a target growing unit",
-								"capacityAvailable": "spaces available"
-							}
-						},
-						"actions": {
-							"submit": {
-								"label": "Transplant",
-								"loading": "Transplanting..."
-							}
-						}
-					},
-					"editDetails": {
-						"title": "Edit Plant Details",
-						"description": "Update the information for this plant",
-						"actions": {
-							"submit": {
-								"label": "Save Changes",
-								"loading": "Saving..."
-							}
-						}
-					}
-				}
-			}
-		},
-		"locations": {
-			"list": {
-				"title": "Locations",
-				"description": "Manage your locations and organize your growing spaces.",
-				"empty": "No locations available",
-				"noDescription": "No description available",
-				"search": {
-					"placeholder": "Search by name or type..."
-				},
-				"filters": {
-					"all": "All",
-					"indoor": "Indoor",
-					"outdoor": "Outdoor"
-				},
-				"actions": {
-					"create": {
-						"button": "Create Location",
-						"title": "Create Location",
-						"description": "Add a new location for your growing spaces",
-						"submit": "Create",
-						"loading": "Creating..."
-					},
-					"update": {
-						"title": "Update Location",
-						"description": "Update location information",
-						"submit": "Update",
-						"loading": "Updating..."
-					},
-					"delete": {
-						"label": "Delete",
-						"loading": "Deleting...",
-						"confirm": {
-							"title": "Delete Location",
-							"description": "Are you sure you want to delete the location {name}? This action cannot be undone."
-						}
-					}
-				},
-				"error": {
-					"loading": "Error loading locations: {message}"
-				}
-			}
-		},
-		"growingUnits": {
-			"list": {
-				"title": "Growing Units",
-				"description": "Visualize and manage your cultivation spaces efficiently.",
-				"empty": "No growing units available",
-				"search": {
-					"placeholder": "Search by name, type or plant..."
-				},
-				"filters": {
-					"all": "All",
-					"indoor": "Indoor",
-					"outdoor": "Outdoor",
-					"pots": "Pots",
-					"beds": "Beds"
-				},
-				"actions": {
-					"create": {
-						"button": "Create Growing Unit",
-						"title": "Create Growing Unit",
-						"description": "Add a new growing unit for your plants",
-						"submit": "Create",
-						"loading": "Creating..."
-					}
-				},
-				"noPlants": "No active plants",
-				"common": {
-					"noDimensions": "No dimensions"
-				}
-			},
-			"detail": {
-				"title": "Growing Unit Detail",
-				"notFound": "Growing unit not found",
-				"error": {
-					"loading": "Error loading growing unit: {message}"
-				},
-				"breadcrumbs": {
-					"home": "Home",
-					"growingUnits": "My Units"
-				},
-				"location": {
-					"label": "Location"
-				},
-				"summary": {
-					"substrate": {
-						"label": "Substrate",
-						"value": "Universal Soil"
-					},
-					"exposure": {
-						"label": "Exposure",
-						"directSun": "Direct Sun",
-						"partialSun": "Partial Sun",
-						"shade": "Shade"
-					},
-					"lastWatering": {
-						"label": "Last Watering",
-						"today": "Today",
-						"yesterday": "Yesterday",
-						"never": "Never"
-					},
-					"occupancy": {
-						"label": "Occupancy"
-					}
-				},
-				"sections": {
-					"plants": {
-						"title": "Plants in cultivation",
-						"variety": "Variety",
-						"planted": "PLANTED",
-						"days": "days",
-						"manage": "Manage"
-					},
-					"history": {
-						"title": "Recent History"
-					}
-				},
-				"actions": {
-					"editUnit": "Edit Unit",
-					"addPlant": "Add Plant",
-					"update": {
-						"title": "Update Growing Unit",
-						"description": "Update growing unit information",
-						"submit": "Update",
-						"loading": "Updating..."
-					},
-					"delete": {
-						"label": "Delete",
-						"loading": "Deleting...",
-						"confirm": {
-							"title": "Delete Growing Unit",
-							"description": "Are you sure you want to delete the growing unit {name}? This action cannot be undone."
-						}
-					}
-				},
-				"fields": {
-					"name": {
-						"label": "Name",
-						"placeholder": "Growing unit name"
-					},
-					"type": {
-						"label": "Type",
-						"placeholder": "Select type"
-					},
-					"capacity": {
-						"label": "Capacity",
-						"placeholder": "Number of plants"
-					},
-					"remainingCapacity": {
-						"label": "Remaining Capacity"
-					},
-					"volume": {
-						"label": "Volume"
-					},
-					"dimensions": {
-						"label": "Dimensions"
-					},
-					"length": {
-						"label": "Length",
-						"placeholder": "Length"
-					},
-					"width": {
-						"label": "Width",
-						"placeholder": "Width"
-					},
-					"height": {
-						"label": "Height",
-						"placeholder": "Height"
-					},
-					"unit": {
-						"label": "Unit",
-						"placeholder": "Select unit"
-					},
-					"plants": {
-						"label": "Active plants"
-					}
-				},
-				"types": {
-					"POT": "Pot",
-					"GARDEN_BED": "Garden Bed",
-					"HANGING_BASKET": "Hanging Basket",
-					"WINDOW_BOX": "Window Box"
-				},
-				"units": {
-					"MILLIMETER": "Millimeter",
-					"CENTIMETER": "Centimeter",
-					"METER": "Meter",
-					"INCH": "Inch",
-					"FOOT": "Foot"
-				},
-				"validation": {
-					"type": {
-						"invalid": "Invalid type"
-					},
-					"capacity": {
-						"required": "Capacity is required"
-					}
-				}
-			}
-		}
-	},
-	"plants": {
-		"actions": {
-			"create": {
-				"title": "Create Plant",
-				"description": "Add a new plant to your collection"
-			}
-		}
-	},
-	"plant": {
-		"fields": {
-			"plantedDate": {
-				"label": "Planted Date"
-			}
-		}
-	},
-	"legacy": {
-		"plant": {
-			"common": {
-				"notSet": "Not set",
-				"unnamed": "Unnamed plant"
-			},
-			"notFound": "Plant not found",
-			"error": {
-				"loading": "Error loading plant: {message}"
-			},
-			"fields": {
-				"name": {
-					"label": "Name",
-					"placeholder": "Plant name"
-				},
-				"species": {
-					"label": "Species",
-					"placeholder": "Plant species"
-				},
-				"plantedDate": {
-					"label": "Planted Date"
-				},
-				"notes": {
-					"label": "Notes",
-					"placeholder": "Additional notes about the plant"
-				},
-				"status": {
-					"label": "Status",
-					"placeholder": "Select status"
-				},
-				"growingUnitId": {
-					"label": "Growing Unit ID"
-				},
-				"sourceGrowingUnitId": {
-					"label": "Source Growing Unit",
-					"placeholder": "Source growing unit ID"
-				},
-				"targetGrowingUnitId": {
-					"label": "Target Growing Unit",
-					"placeholder": "Target growing unit ID"
-				}
-			},
-			"status": {
-				"PLANTED": "Planted",
-				"GROWING": "Growing",
-				"HARVESTED": "Harvested",
-				"DEAD": "Dead",
-				"ARCHIVED": "Archived"
-			},
-			"sections": {
-				"info": {
-					"title": "Plant Information",
-					"description": "Detailed information about the plant"
-				},
-				"update": {
-					"title": "Update Plant",
-					"description": "Update plant information"
-				},
-				"transplant": {
-					"title": "Transplant Plant",
-					"description": "Move plant to a different growing unit"
-				}
-			},
-			"actions": {
-				"update": {
-					"label": "Update Plant",
-					"loading": "Updating..."
-				},
-				"transplant": {
-					"label": "Transplant",
-					"loading": "Transplanting..."
-				}
-			},
-			"transplant": {
-				"title": "Transplant Plant",
-				"description": "Move this plant to a different growing unit",
-				"fields": {
-					"sourceGrowingUnit": {
-						"label": "From",
-						"unknown": "Unknown growing unit",
-						"helper": "Current growing unit (cannot be changed)"
-					},
-					"targetGrowingUnitId": {
-						"label": "To",
-						"placeholder": "Select a target growing unit",
-						"required": "You must select a target growing unit",
-						"capacityAvailable": "spaces available"
-					}
-				},
-				"actions": {
-					"submit": {
-						"label": "Transplant",
-						"loading": "Transplanting..."
-					}
-				}
-			},
-			"validation": {
-				"id": {
-					"required": "ID is required"
-				},
-				"plantId": {
-					"required": "Plant ID is required"
-				},
-				"sourceGrowingUnitId": {
-					"required": "Source growing unit ID is required"
-				},
-				"targetGrowingUnitId": {
-					"required": "Target growing unit ID is required"
-				}
-			},
-			"detail": {
-				"image": {
-					"placeholder": "Plant image placeholder"
-				},
-				"location": {
-					"indoor": "INDOOR",
-					"outdoor": "OUTDOOR"
-				},
-				"actions": {
-					"registerWatering": "Register Watering",
-					"fertilize": "Fertilize"
-				},
-				"metrics": {
-					"title": "Care Requirements",
-					"watering": {
-						"label": "WATERING",
-						"every7Days": "Every 7 days"
-					},
-					"light": {
-						"label": "LIGHT",
-						"indirect": "Indirect"
-					},
-					"temperature": {
-						"label": "TEMP"
-					},
-					"humidity": {
-						"label": "HUMIDITY",
-						"high": "High"
-					}
-				},
-				"currentStatus": {
-					"lastWatering": {
-						"label": "Last Watering",
-						"onTime": "On time",
-						"daysAgo": "Days ago",
-						"next": "Next",
-						"tomorrow": "Tomorrow"
-					},
-					"lastFertilization": {
-						"label": "Last Fertilization",
-						"pending": "Pending",
-						"monthAgo": "{months} month ago",
-						"suggested": "Suggested",
-						"today": "Today"
-					},
-					"plantingDate": {
-						"label": "Planting Date",
-						"age": "Age"
-					}
-				},
-				"age": {
-					"yearsMonths": "{years} year {months} months",
-					"years": "{years} year",
-					"months": "{months} months",
-					"days": "{days} days"
-				},
-				"personalNotes": {
-					"title": "Personal Notes",
-					"edit": "Edit Notes",
-					"empty": "No personal notes yet. Add some notes about your plant care routine!"
-				},
-				"upcomingCare": {
-					"title": "Upcoming Care",
-					"tomorrow": "TOMORROW",
-					"lightWatering": "Light Watering",
-					"in5Days": "IN 5 DAYS",
-					"cleanLeaves": "Clean Leaves",
-					"duringDay": "During the day",
-					"in2Weeks": "IN 2 WEEKS",
-					"fertilization": "Fertilization",
-					"spring": "Spring"
-				},
-				"recentHistory": {
-					"title": "Recent History",
-					"viewAll": "View all",
-					"today": "Today",
-					"watering": "Watering",
-					"wateringDetails": "250ml filtered water",
-					"pruning": "Pruning",
-					"pruningDetails": "Lower yellow leaves",
-					"fertilization": "Fertilization",
-					"fertilizationDetails": "Liquid fertilizer NPK 20-20-20",
-					"completed": "Completed",
-					"table": {
-						"date": "DATE",
-						"action": "ACTION",
-						"details": "DETAILS",
-						"status": "STATUS"
-					}
-				},
-				"progressGallery": {
-					"title": "Progress Gallery",
-					"more": "more"
-				},
-				"wiki": {
-					"title": "Plant Wiki",
-					"didYouKnow": "Did you know...",
-					"description": "Monstera Deliciosa is also known as 'Adam's Rib' due to the unique shape of its leaves that develop natural holes (fenestrations) as they mature.",
-					"readMore": "READ MORE"
-				}
-			}
-		},
-		"plants": {
-			"title": "Plant List",
-			"description": "Manage your botanical collection and monitor its health",
-			"empty": {
-				"default": "No plants registered",
-				"filtered": "No plants match the current filters"
-			},
-			"growingUnit": {
-				"plantCount": "{count} of {total} plants"
-			},
-			"search": {
-				"placeholder": "Search by name, species or location..."
-			},
-			"filters": {
-				"all": "All",
-				"indoor": "Indoor",
-				"outdoor": "Outdoor",
-				"needsWater": "Needs Water",
-				"healthy": "Healthy"
-			},
-			"table": {
-				"columns": {
-					"plant": "PLANT / SPECIES",
-					"location": "LOCATION",
-					"status": "STATUS",
-					"lastWatering": "LAST WATERING",
-					"actions": "ACTIONS"
-				},
-				"lastWatering": {
-					"today": "Today",
-					"yesterday": "Yesterday",
-					"daysAgo": "{days} days ago",
-					"weeksAgo": "{weeks} weeks ago"
-				},
-				"pagination": {
-					"showing": "Showing {from} to {to} of {total} plants"
-				}
-			},
-			"actions": {
-				"create": {
-					"button": "Add Plant",
-					"title": "Create Plant",
-					"description": "Add a new plant to your collection",
-					"submit": "Create",
-					"loading": "Creating..."
-				},
-				"view": "View",
-				"edit": "Edit",
-				"delete": "Delete"
-			},
-			"pagination": {
-				"info": "Page {page} of {totalPages} ({total} total)"
-			}
-		},
-		"growingUnit": {
-			"page": {
-				"title": "Growing Units",
-				"description": "Visualize and manage your cultivation spaces efficiently."
-			},
-			"common": {
-				"noDimensions": "No dimensions",
-				"more": "more"
-			},
-			"error": {
-				"loading": "Error loading growing units: {message}"
-			},
-			"search": {
-				"placeholder": "Search by name, type or plant..."
-			},
-			"filters": {
-				"all": "All",
-				"indoor": "Indoor",
-				"outdoor": "Outdoor",
-				"pots": "Pots",
-				"beds": "Beds"
-			},
-			"fields": {
-				"name": {
-					"label": "Name",
-					"placeholder": "Growing unit name"
-				},
-				"type": {
-					"label": "Type",
-					"placeholder": "Select type"
-				},
-				"capacity": {
-					"label": "Capacity",
-					"placeholder": "Number of plants"
-				},
-				"remainingCapacity": {
-					"label": "Remaining Capacity"
-				},
-				"volume": {
-					"label": "Volume"
-				},
-				"dimensions": {
-					"label": "Dimensions"
-				},
-				"length": {
-					"label": "Length",
-					"placeholder": "Length"
-				},
-				"width": {
-					"label": "Width",
-					"placeholder": "Width"
-				},
-				"height": {
-					"label": "Height",
-					"placeholder": "Height"
-				},
-				"unit": {
-					"label": "Unit",
-					"placeholder": "Select unit"
-				},
-				"plants": {
-					"label": "Active plants"
-				},
-				"createdAt": {
-					"label": "Created at"
-				}
-			},
-			"noPlants": "No active plants",
-			"detail": {
-				"notFound": "Growing unit not found",
-				"error": {
-					"loading": "Error loading growing unit: {message}"
-				},
-				"breadcrumbs": {
-					"home": "Home",
-					"growingUnits": "My Units"
-				},
-				"status": {
-					"active": "ACTIVE",
-					"inactive": "INACTIVE"
-				},
-				"location": {
-					"label": "Location",
-					"indoor": "Indoor",
-					"outdoor": "Outdoor"
-				},
-				"summary": {
-					"substrate": {
-						"label": "Substrate",
-						"value": "Universal Soil"
-					},
-					"exposure": {
-						"label": "Exposure",
-						"directSun": "Direct Sun",
-						"partialSun": "Partial Sun",
-						"shade": "Shade"
-					},
-					"lastWatering": {
-						"label": "Last Watering",
-						"today": "Today",
-						"yesterday": "Yesterday",
-						"never": "Never"
-					},
-					"occupancy": {
-						"label": "Occupancy"
-					}
-				},
-				"plants": {
-					"title": "Plants in cultivation",
-					"viewAll": "View all",
-					"variety": "Variety",
-					"planted": "PLANTED",
-					"days": "days",
-					"manage": "Manage"
-				},
-				"history": {
-					"title": "Recent History",
-					"viewAll": "View all history",
-					"today": "TODAY",
-					"yesterday": "YESTERDAY"
-				},
-				"actions": {
-					"editUnit": "Edit Unit",
-					"addPlant": "Add Plant"
-				}
-			},
-			"type": {
-				"POT": "Pot",
-				"GARDEN_BED": "Garden Bed",
-				"HANGING_BASKET": "Hanging Basket",
-				"WINDOW_BOX": "Window Box"
-			},
-			"unit": {
-				"MILLIMETER": "Millimeter",
-				"CENTIMETER": "Centimeter",
-				"METER": "Meter",
-				"INCH": "Inch",
-				"FOOT": "Foot"
-			},
-			"actions": {
-				"create": {
-					"title": "Create Growing Unit",
-					"description": "Add a new growing unit for your plants",
-					"button": "Create Growing Unit",
-					"submit": "Create",
-					"loading": "Creating..."
-				},
-				"update": {
-					"title": "Update Growing Unit",
-					"description": "Update growing unit information",
-					"submit": "Update",
-					"loading": "Updating..."
-				},
-				"edit": "Edit",
-				"delete": {
-					"label": "Delete",
-					"loading": "Deleting...",
-					"confirm": {
-						"title": "Delete Growing Unit",
-						"description": "Are you sure you want to delete the growing unit {name}? This action cannot be undone."
-					}
-				}
-			},
-			"pagination": {
-				"info": "Page {page} of {totalPages} ({total} total)"
-			},
-			"validation": {
-				"id": {
-					"required": "ID is required"
-				},
-				"name": {
-					"required": "Name is required"
-				},
-				"type": {
-					"invalid": "Invalid type"
-				},
-				"capacity": {
-					"required": "Capacity is required"
-				}
-			}
-		},
-		"user": {
-			"loading": "Loading user...",
-			"notFound": "User not found",
-			"validation": {
-				"species": {
-					"required": "Species is required"
-				},
-				"status": {
-					"invalid": "Invalid status"
-				},
-				"growingUnitId": {
-					"required": "Growing unit ID is required"
-				}
-			}
-		},
-		"authPage": {
-			"title": {
-				"login": "Welcome back",
-				"signup": "Create an account"
-			},
-			"description": {
-				"login": "Enter your email and password to sign in",
-				"signup": "Enter your information to create a new account"
-			},
-			"fields": {
-				"email": {
-					"label": "Email",
-					"placeholder": "name@example.com"
-				},
-				"password": {
-					"label": "Password",
-					"placeholder": {
-						"login": "Enter your password",
-						"signup": "At least 8 characters"
-					}
-				},
-				"confirmPassword": {
-					"label": "Confirm Password",
-					"placeholder": "Confirm your password"
-				}
-			},
-			"actions": {
-				"login": "Sign in",
-				"signup": "Create account",
-				"switchToSignup": "Sign up",
-				"switchToLogin": "Sign in",
-				"loading": {
-					"login": "Signing in...",
-					"signup": "Creating account..."
-				}
-			},
-			"messages": {
-				"switchToSignup": "Don't have an account?",
-				"switchToLogin": "Already have an account?",
-				"error": "An error occurred. Please try again."
-			},
-			"validation": {
-				"email": {
-					"required": "Email is required",
-					"invalid": "Invalid email format"
-				},
-				"password": {
-					"required": "Password is required",
-					"minLength": "Password must be at least 8 characters"
-				},
-				"confirmPassword": {
-					"required": "Please confirm your password",
-					"mismatch": "Passwords don't match"
-				}
-			}
-		}
-	}
+  "common": {
+    "loading": "Loading...",
+    "error": "Error",
+    "unknown": "Unknown",
+    "cancel": "Cancel",
+    "delete": "Delete",
+    "edit": "Edit",
+    "view": "View",
+    "create": "Create",
+    "update": "Update",
+    "submit": "Submit",
+    "save": "Save",
+    "close": "Close",
+    "back": "Back",
+    "next": "Next",
+    "previous": "Previous",
+    "search": "Search",
+    "filter": "Filter",
+    "all": "All",
+    "none": "None",
+    "empty": "Empty",
+    "notSet": "Not set",
+    "notFound": "Not found",
+    "today": "Today",
+    "yesterday": "Yesterday",
+    "tomorrow": "Tomorrow",
+    "completed": "Completed",
+    "pending": "Pending",
+    "viewAll": "View all",
+    "seeAll": "See all"
+  },
+  "nav": {
+    "home": "Home",
+    "settings": "Settings",
+    "plants": "Plants",
+    "growingUnits": "Growing Units",
+    "locations": "Locations",
+    "search": "Search",
+    "searchPlaceholder": "Search..."
+  },
+  "fields": {
+    "name": {
+      "label": "Name",
+      "placeholder": "Enter name"
+    },
+    "status": {
+      "label": "Status",
+      "placeholder": "Select status"
+    },
+    "createdAt": {
+      "label": "Created at"
+    },
+    "updatedAt": {
+      "label": "Updated at"
+    },
+    "type": {
+      "label": "Type",
+      "placeholder": "Select type"
+    },
+    "locationId": {
+      "label": "Location",
+      "placeholder": "Select a location"
+    },
+    "capacity": {
+      "label": "Capacity",
+      "placeholder": "Number of items"
+    },
+    "remainingCapacity": {
+      "label": "Remaining Capacity"
+    },
+    "volume": {
+      "label": "Volume"
+    },
+    "dimensions": {
+      "label": "Dimensions"
+    },
+    "length": {
+      "label": "Length",
+      "placeholder": "Length"
+    },
+    "width": {
+      "label": "Width",
+      "placeholder": "Width"
+    },
+    "height": {
+      "label": "Height",
+      "placeholder": "Height"
+    },
+    "unit": {
+      "label": "Unit",
+      "placeholder": "Select unit"
+    },
+    "plants": {
+      "label": "Active plants"
+    },
+    "species": {
+      "label": "Species",
+      "placeholder": "Species"
+    },
+    "plantedDate": {
+      "label": "Planting date"
+    },
+    "notes": {
+      "label": "Notes",
+      "placeholder": "Additional notes"
+    },
+    "description": {
+      "label": "Description",
+      "placeholder": "Enter description"
+    },
+    "growingUnitId": {
+      "label": "Growing Unit ID"
+    }
+  },
+  "types": {
+    "growingUnit": {
+      "POT": "Pot",
+      "GARDEN_BED": "Garden bed",
+      "HANGING_BASKET": "Hanging basket",
+      "WINDOW_BOX": "Window box"
+    },
+    "location": {
+      "ROOM": "Room",
+      "BALCONY": "Balcony",
+      "GARDEN": "Garden",
+      "GREENHOUSE": "Greenhouse",
+      "OUTDOOR_SPACE": "Outdoor Space",
+      "INDOOR_SPACE": "Indoor Space"
+    }
+  },
+  "units": {
+    "length": {
+      "MILLIMETER": "Millimeter",
+      "CENTIMETER": "Centimeter",
+      "METER": "Meter",
+      "INCH": "Inch",
+      "FOOT": "Foot"
+    }
+  },
+  "status": {
+    "plant": {
+      "PLANTED": "Planted",
+      "GROWING": "Growing",
+      "HARVESTED": "Harvested",
+      "DEAD": "Dead",
+      "ARCHIVED": "Archived"
+    },
+    "growingUnit": {
+      "active": "ACTIVE",
+      "inactive": "INACTIVE"
+    },
+    "location": {
+      "indoor": "Indoor",
+      "outdoor": "Outdoor"
+    }
+  },
+  "validation": {
+    "required": "This field is required",
+    "invalid": "Invalid value",
+    "id": {
+      "required": "ID is required"
+    },
+    "name": {
+      "required": "Name is required"
+    },
+    "type": {
+      "invalid": "Invalid type"
+    },
+    "locationId": {
+      "required": "Location is required"
+    },
+    "capacity": {
+      "required": "Capacity is required"
+    },
+    "unit": {
+      "invalid": "Invalid unit"
+    }
+  },
+  "pagination": {
+    "info": "Page {page} of {totalPages} ({total} total)",
+    "showing": "Showing {from} to {to} of {total}"
+  },
+  "time": {
+    "daysAgo": "{days} days ago",
+    "weeksAgo": "{weeks} weeks ago",
+    "monthsAgo": "{months} month ago",
+    "yearsAgo": "{years} years ago"
+  }
 }

--- a/apps/web/shared/locales/es.json
+++ b/apps/web/shared/locales/es.json
@@ -1,1409 +1,190 @@
 {
-	"common": {
-		"loading": "Cargando...",
-		"error": "Error",
-		"unknown": "Desconocido",
-		"cancel": "Cancelar",
-		"delete": "Eliminar",
-		"edit": "Editar",
-		"view": "Ver",
-		"create": "Crear",
-		"update": "Actualizar",
-		"submit": "Enviar",
-		"save": "Guardar",
-		"close": "Cerrar",
-		"back": "Volver",
-		"next": "Siguiente",
-		"previous": "Anterior",
-		"search": "Buscar",
-		"filter": "Filtrar",
-		"all": "Todos",
-		"none": "Ninguno",
-		"empty": "Vacío",
-		"notSet": "No establecido",
-		"notFound": "No encontrado",
-		"today": "Hoy",
-		"yesterday": "Ayer",
-		"tomorrow": "Mañana",
-		"completed": "Completado",
-		"pending": "Pendiente",
-		"viewAll": "Ver todo",
-		"seeAll": "Ver todas"
-	},
-	"nav": {
-		"home": "Inicio",
-		"settings": "Configuración",
-		"plants": "Plantas",
-		"growingUnits": "Unidades de Cultivo",
-		"locations": "Ubicaciones",
-		"search": "Buscar",
-		"searchPlaceholder": "Buscar..."
-	},
-	"dashboard": {
-		"page": {
-			"title": "Panel de Control",
-			"description": "Bienvenido de nuevo, aquí tienes el resumen de hoy.",
-			"addPlantButton": "Añadir Planta"
-		},
-		"error": {
-			"loading": "Error al cargar el dashboard: {message}"
-		},
-		"stats": {
-			"totalPlants": {
-				"title": "Total Plantas"
-			},
-			"activeUnits": {
-				"title": "Unidades Activas"
-			},
-			"readyForHarvest": {
-				"title": "Listas para Cosecha"
-			},
-			"criticalAlerts": {
-				"title": "Alertas Críticas"
-			},
-			"changeSuffix": "vs mes anterior"
-		},
-		"sections": {
-			"plants": {
-				"title": "Resumen de Plantas",
-				"totalPlants": "Total Plantas",
-				"activePlants": "Plantas Activas",
-				"activePercentage": "{percentage}% activas",
-				"statusBreakdown": "Desglose por Estado",
-				"additionalMetrics": "Métricas Adicionales",
-				"planted": "Plantadas",
-				"growing": "Creciendo",
-				"harvested": "Cosechadas",
-				"dead": "Muertas",
-				"archived": "Archivadas",
-				"withoutPlantedDate": "Sin Fecha de Plantación",
-				"withNotes": "Con Notas",
-				"recent7Days": "Recientes (7 días)"
-			},
-			"capacity": {
-				"title": "Resumen de Capacidad",
-				"averageOccupancy": "Ocupación Promedio",
-				"totalCapacity": "Capacidad Total",
-				"used": "Usada",
-				"available": "Disponible",
-				"atLimit": "En Límite (≥80%)",
-				"full": "Llena (100%)"
-			},
-			"growingUnits": {
-				"title": "Resumen de Unidades de Cultivo",
-				"totalGrowingUnits": "Total Unidades de Cultivo",
-				"active": "Activas",
-				"empty": "Vacías",
-				"byType": "Por Tipo",
-				"percentageOfTotal": "{percentage}% del total",
-				"avgPlantsPerUnit": "Prom. Plantas/Unidad",
-				"min": "Mín",
-				"max": "Máx",
-				"pots": "Macetas",
-				"gardenBeds": "Bancales",
-				"hangingBaskets": "Cestas Colgantes",
-				"windowBoxes": "Jardines de Ventana"
-			},
-			"growingUnitsStatus": {
-				"title": "Estado de Unidades de Cultivo",
-				"empty": "No hay unidades de cultivo disponibles"
-			},
-			"recentAlerts": {
-				"title": "Alertas Recientes",
-				"empty": "No hay alertas recientes"
-			},
-			"todayTasks": {
-				"title": "Tareas de Hoy",
-				"assignedTo": "Asignado a",
-				"empty": "No hay tareas programadas para hoy"
-			}
-		},
-		"common": {
-			"retry": "Reintentar",
-			"active": "activas",
-			"total": "total",
-			"growing": "creciendo",
-			"atLimit": "en límite"
-		}
-	},
-	"shared": {
-		"fields": {
-			"name": {
-				"label": "Nombre",
-				"placeholder": "Ingresa el nombre"
-			},
-			"status": {
-				"label": "Estado",
-				"placeholder": "Selecciona el estado"
-			},
-			"createdAt": {
-				"label": "Fecha de creación"
-			},
-			"updatedAt": {
-				"label": "Fecha de actualización"
-			},
-			"type": {
-				"label": "Tipo",
-				"placeholder": "Selecciona el tipo"
-			},
-			"locationId": {
-				"label": "Ubicación",
-				"placeholder": "Selecciona una ubicación"
-			},
-			"capacity": {
-				"label": "Capacidad",
-				"placeholder": "Número de elementos"
-			},
-			"remainingCapacity": {
-				"label": "Capacidad Restante"
-			},
-			"volume": {
-				"label": "Volumen"
-			},
-			"dimensions": {
-				"label": "Dimensiones"
-			},
-			"length": {
-				"label": "Longitud",
-				"placeholder": "Longitud"
-			},
-			"width": {
-				"label": "Ancho",
-				"placeholder": "Ancho"
-			},
-			"height": {
-				"label": "Altura",
-				"placeholder": "Altura"
-			},
-			"unit": {
-				"label": "Unidad",
-				"placeholder": "Selecciona la unidad"
-			},
-			"plants": {
-				"label": "Plantas activas"
-			},
-			"species": {
-				"label": "Especie",
-				"placeholder": "Especie"
-			},
-			"plantedDate": {
-				"label": "Fecha de plantación"
-			},
-			"notes": {
-				"label": "Notas",
-				"placeholder": "Notas adicionales"
-			},
-			"description": {
-				"label": "Descripción",
-				"placeholder": "Ingresa la descripción"
-			},
-			"growingUnitId": {
-				"label": "Unidad de Cultivo"
-			}
-		},
-		"types": {
-			"growingUnit": {
-				"POT": "Maceta",
-				"GARDEN_BED": "Cama de jardín",
-				"HANGING_BASKET": "Cesta colgante",
-				"WINDOW_BOX": "Jardín de ventana"
-			},
-			"location": {
-				"ROOM": "Habitación",
-				"BALCONY": "Balcón",
-				"GARDEN": "Jardín",
-				"GREENHOUSE": "Invernadero",
-				"OUTDOOR_SPACE": "Espacio Exterior",
-				"INDOOR_SPACE": "Espacio Interior"
-			}
-		},
-		"units": {
-			"length": {
-				"MILLIMETER": "Milímetro",
-				"CENTIMETER": "Centímetro",
-				"METER": "Metro",
-				"INCH": "Pulgada",
-				"FOOT": "Pie"
-			}
-		},
-		"status": {
-			"plant": {
-				"PLANTED": "Plantada",
-				"GROWING": "Creciendo",
-				"HARVESTED": "Cosechada",
-				"DEAD": "Muerta",
-				"ARCHIVED": "Archivada"
-			},
-			"growingUnit": {
-				"active": "ACTIVA",
-				"inactive": "INACTIVA"
-			},
-			"location": {
-				"indoor": "Interior",
-				"outdoor": "Exterior"
-			}
-		},
-		"validation": {
-			"required": "Este campo es requerido",
-			"invalid": "Valor inválido",
-			"id": {
-				"required": "El ID es requerido"
-			},
-			"name": {
-				"required": "El nombre es requerido"
-			},
-			"species": {
-				"required": "La especie es requerida"
-			},
-			"status": {
-				"invalid": "Estado inválido"
-			},
-			"growingUnitId": {
-				"required": "El ID de la unidad de cultivo es requerido"
-			},
-			"plantId": {
-				"required": "El ID de la planta es requerido"
-			},
-			"sourceGrowingUnitId": {
-				"required": "El ID de la unidad de cultivo origen es requerido"
-			},
-			"targetGrowingUnitId": {
-				"required": "El ID de la unidad de cultivo destino es requerido"
-			},
-			"type": {
-				"invalid": "Tipo inválido"
-			},
-			"locationId": {
-				"required": "La ubicación es requerida"
-			},
-			"capacity": {
-				"required": "La capacidad es requerida"
-			},
-			"unit": {
-				"invalid": "Unidad inválida"
-			}
-		},
-		"pagination": {
-			"info": "Página {page} de {totalPages} ({total} en total)",
-			"showing": "Mostrando {from} a {to} de {total}"
-		},
-		"time": {
-			"daysAgo": "Hace {days} días",
-			"weeksAgo": "Hace {weeks} semanas",
-			"monthsAgo": "Hace {months} mes{months, plural, =1 {} other {es}}",
-			"yearsAgo": "Hace {years} años"
-		}
-	},
-	"pages": {
-		"dashboard": {
-			"title": "Panel de Control",
-			"description": "Bienvenido de nuevo, aquí tienes el resumen de hoy.",
-			"addPlantButton": "Añadir Planta",
-			"error": {
-				"loading": "Error al cargar el dashboard: {message}"
-			},
-			"stats": {
-				"totalPlants": {
-					"title": "Total Plantas"
-				},
-				"activeUnits": {
-					"title": "Unidades Activas"
-				},
-				"readyForHarvest": {
-					"title": "Listas para Cosecha"
-				},
-				"criticalAlerts": {
-					"title": "Alertas Críticas"
-				},
-				"changeSuffix": "vs mes anterior"
-			},
-			"sections": {
-				"growingUnitsStatus": {
-					"title": "Estado de Unidades de Cultivo",
-					"empty": "No hay unidades de cultivo disponibles"
-				},
-				"recentAlerts": {
-					"title": "Alertas Recientes",
-					"empty": "No hay alertas recientes"
-				},
-				"todayTasks": {
-					"title": "Tareas de Hoy",
-					"assignedTo": "Asignado a",
-					"empty": "No hay tareas programadas para hoy"
-				}
-			}
-		},
-		"auth": {
-			"title": {
-				"login": "Bienvenido de nuevo",
-				"signup": "Crear una cuenta"
-			},
-			"description": {
-				"login": "Ingresa tu email y contraseña para iniciar sesión",
-				"signup": "Ingresa tu información para crear una nueva cuenta"
-			},
-			"fields": {
-				"email": {
-					"label": "Email",
-					"placeholder": "nombre@ejemplo.com"
-				},
-				"password": {
-					"label": "Contraseña",
-					"placeholder": {
-						"login": "Ingresa tu contraseña",
-						"signup": "Al menos 8 caracteres"
-					}
-				},
-				"confirmPassword": {
-					"label": "Confirmar contraseña",
-					"placeholder": "Confirma tu contraseña"
-				}
-			},
-			"actions": {
-				"login": "Iniciar sesión",
-				"signup": "Crear cuenta",
-				"switchToSignup": "Registrarse",
-				"switchToLogin": "Iniciar sesión",
-				"loading": {
-					"login": "Iniciando sesión...",
-					"signup": "Creando cuenta..."
-				}
-			},
-			"messages": {
-				"switchToSignup": "¿No tienes una cuenta?",
-				"switchToLogin": "¿Ya tienes una cuenta?",
-				"error": "Ocurrió un error. Por favor intenta de nuevo."
-			},
-			"validation": {
-				"email": {
-					"required": "El email es requerido",
-					"invalid": "Formato de email inválido"
-				},
-				"password": {
-					"required": "La contraseña es requerida",
-					"minLength": "La contraseña debe tener al menos 8 caracteres"
-				},
-				"confirmPassword": {
-					"required": "Por favor confirma tu contraseña",
-					"mismatch": "Las contraseñas no coinciden"
-				}
-			}
-		},
-		"user": {
-			"profile": {
-				"title": "Perfil de Usuario",
-				"anonymous": "Usuario anónimo",
-				"error": {
-					"loading": "Error al cargar usuario: {message}"
-				},
-				"sections": {
-					"personalInfo": {
-						"title": "Información Personal",
-						"description": "Datos personales y de identificación"
-					},
-					"authInfo": {
-						"title": "Información de Autenticación",
-						"description": "Configuración de seguridad y autenticación"
-					},
-					"accountInfo": {
-						"title": "Información de Cuenta",
-						"description": "Detalles de la cuenta y actividad"
-					},
-					"contactInfo": {
-						"title": "Información de Contacto",
-						"description": "Datos de contacto y comunicación"
-					},
-					"editProfile": {
-						"title": "Editar Perfil",
-						"description": "Actualiza tu información personal"
-					}
-				},
-				"fields": {
-					"email": "Correo electrónico",
-					"verified": "Verificado",
-					"unverified": "No verificado",
-					"provider": "Proveedor de autenticación",
-					"twoFactor": "Autenticación de dos factores",
-					"enabled": "Habilitado",
-					"disabled": "Deshabilitado",
-					"createdAt": "Fecha de creación",
-					"lastLoginAt": "Último inicio de sesión",
-					"phoneNumber": "Número de teléfono",
-					"name": {
-						"label": "Nombre",
-						"placeholder": "Ingresa tu nombre"
-					},
-					"lastName": {
-						"label": "Apellido",
-						"placeholder": "Ingresa tu apellido"
-					},
-					"userName": {
-						"label": "Nombre de usuario",
-						"placeholder": "Ingresa tu nombre de usuario"
-					},
-					"bio": {
-						"label": "Biografía",
-						"placeholder": "Escribe una breve biografía sobre ti"
-					},
-					"avatarUrl": {
-						"label": "URL del avatar",
-						"placeholder": "https://ejemplo.com/avatar.jpg"
-					},
-					"role": {
-						"label": "Rol"
-					},
-					"status": {
-						"label": "Estado"
-					}
-				},
-				"actions": {
-					"update": {
-						"label": "Actualizar perfil",
-						"loading": "Actualizando..."
-					}
-				}
-			}
-		},
-		"plants": {
-			"list": {
-				"title": "Lista de Plantas",
-				"description": "Gestiona tu colección botánica y monitorea su salud",
-				"empty": "No hay plantas registradas",
-				"emptyFiltered": "No hay plantas que coincidan con los filtros actuales",
-				"search": {
-					"placeholder": "Buscar por nombre, especie o ubicación..."
-				},
-				"filters": {
-					"all": "Todas",
-					"indoor": "Interior",
-					"outdoor": "Exterior",
-					"needsWater": "Necesita Agua",
-					"healthy": "Saludables"
-				},
-				"table": {
-					"columns": {
-						"plant": "PLANTA / ESPECIE",
-						"location": "UBICACIÓN",
-						"status": "ESTADO",
-						"lastWatering": "ÚLTIMO RIEGO",
-						"actions": "ACCIONES"
-					},
-					"lastWatering": {
-						"today": "Hoy",
-						"yesterday": "Ayer",
-						"daysAgo": "Hace {days} días",
-						"weeksAgo": "Hace {weeks} semanas"
-					}
-				},
-				"actions": {
-					"create": {
-						"button": "Añadir Planta",
-						"title": "Crear Planta",
-						"description": "Agrega una nueva planta a tu colección",
-						"submit": "Crear",
-						"loading": "Creando..."
-					},
-					"view": "Ver",
-					"edit": "Editar",
-					"delete": "Eliminar"
-				},
-				"error": {
-					"loading": "Error al cargar plantas: {message}"
-				},
-				"growingUnit": {
-					"plantCount": "{count} de {total} plantas"
-				}
-			},
-			"detail": {
-				"title": "Detalle de Planta",
-				"notFound": "Planta no encontrada",
-				"unnamed": "Planta sin nombre",
-				"error": {
-					"loading": "Error al cargar planta: {message}"
-				},
-				"fields": {
-					"name": {
-						"label": "Nombre",
-						"placeholder": "Nombre de la planta"
-					},
-					"species": {
-						"label": "Especie",
-						"placeholder": "Especie de la planta"
-					},
-					"plantedDate": {
-						"label": "Fecha de plantación"
-					},
-					"notes": {
-						"label": "Notas",
-						"placeholder": "Notas adicionales sobre la planta"
-					},
-					"growingUnitId": {
-						"label": "Unidad de Cultivo",
-						"placeholder": "Selecciona una unidad de cultivo"
-					}
-				},
-				"location": {
-					"indoor": "INTERIOR",
-					"outdoor": "EXTERIOR"
-				},
-				"actions": {
-					"editDetails": "Editar Detalles",
-					"registerWatering": "Registrar Riego",
-					"fertilize": "Fertilizar",
-					"transplant": "Trasplantar"
-				},
-				"metrics": {
-					"title": "Requisitos de Cuidado",
-					"watering": {
-						"label": "RIEGO",
-						"every7Days": "Cada 7 días"
-					},
-					"light": {
-						"label": "LUZ",
-						"indirect": "Indirecta"
-					},
-					"temperature": {
-						"label": "TEMP"
-					},
-					"humidity": {
-						"label": "HUMEDAD",
-						"high": "Alta"
-					}
-				},
-				"currentStatus": {
-					"lastWatering": {
-						"label": "Último Riego",
-						"onTime": "A tiempo",
-						"next": "Próximo"
-					},
-					"lastFertilization": {
-						"label": "Última Fertilización",
-						"suggested": "Sugerido"
-					},
-					"plantingDate": {
-						"label": "Fecha de Plantación",
-						"age": "Edad"
-					}
-				},
-				"age": {
-					"yearsMonths": "{years} año {months} meses",
-					"years": "{years} año",
-					"months": "{months} meses",
-					"days": "{days} días"
-				},
-				"sections": {
-					"personalNotes": {
-						"title": "Notas Personales",
-						"edit": "Editar Notas",
-						"empty": "Aún no hay notas personales. ¡Agrega algunas notas sobre tu rutina de cuidado de plantas!"
-					},
-					"upcomingCare": {
-						"title": "Próximos Cuidados",
-						"tomorrow": "MAÑANA",
-						"lightWatering": "Riego Ligero",
-						"in5Days": "EN 5 DÍAS",
-						"cleanLeaves": "Limpiar Hojas",
-						"duringDay": "Durante el día",
-						"in2Weeks": "EN 2 SEMANAS",
-						"fertilization": "Fertilización",
-						"spring": "Primavera"
-					},
-					"recentHistory": {
-						"title": "Historial Reciente",
-						"watering": "Riego",
-						"wateringDetails": "250ml de agua filtrada",
-						"pruning": "Poda",
-						"pruningDetails": "Hojas amarillas inferiores",
-						"fertilization": "Fertilización",
-						"fertilizationDetails": "Fertilizante líquido NPK 20-20-20",
-						"table": {
-							"date": "FECHA",
-							"action": "ACCIÓN",
-							"details": "DETALLES",
-							"status": "ESTADO"
-						}
-					},
-					"progressGallery": {
-						"title": "Galería de Progreso",
-						"more": "más"
-					},
-					"wiki": {
-						"title": "Wiki Planta",
-						"didYouKnow": "Sabías que...",
-						"description": "La Monstera Deliciosa también es conocida como 'Costilla de Adán' debido a la forma única de sus hojas que desarrollan agujeros naturales (fenestraciones) a medida que maduran.",
-						"readMore": "LEER MÁS"
-					}
-				},
-				"modals": {
-					"transplant": {
-						"title": "Trasplantar Planta",
-						"description": "Mueve esta planta a una unidad de cultivo diferente",
-						"fields": {
-							"sourceGrowingUnit": {
-								"label": "Desde",
-								"unknown": "Unidad de cultivo desconocida",
-								"helper": "Unidad de cultivo actual (no se puede cambiar)"
-							},
-							"targetGrowingUnitId": {
-								"label": "Hacia",
-								"placeholder": "Selecciona una unidad de cultivo destino",
-								"required": "Debes seleccionar una unidad de cultivo destino",
-								"capacityAvailable": "espacios disponibles"
-							}
-						},
-						"actions": {
-							"submit": {
-								"label": "Trasplantar",
-								"loading": "Trasplantando..."
-							}
-						}
-					},
-					"editDetails": {
-						"title": "Editar Detalles de la Planta",
-						"description": "Actualiza la información de esta planta",
-						"actions": {
-							"submit": {
-								"label": "Guardar Cambios",
-								"loading": "Guardando..."
-							}
-						}
-					}
-				}
-			}
-		},
-		"locations": {
-			"list": {
-				"title": "Ubicaciones",
-				"description": "Gestiona tus ubicaciones y organiza tus espacios de cultivo.",
-				"empty": "No hay ubicaciones disponibles",
-				"noDescription": "Sin descripción disponible",
-				"search": {
-					"placeholder": "Buscar por nombre o tipo..."
-				},
-				"filters": {
-					"all": "Todas",
-					"indoor": "Interior",
-					"outdoor": "Exterior"
-				},
-        "actions": {
-          "create": {
-            "button": "Crear Ubicación",
-            "title": "Crear Ubicación",
-            "description": "Agrega una nueva ubicación para tus espacios de cultivo",
-            "submit": "Crear",
-            "loading": "Creando..."
-          },
-          "update": {
-            "title": "Actualizar Ubicación",
-            "description": "Actualizar información de la ubicación",
-            "submit": "Actualizar",
-            "loading": "Actualizando..."
-          },
-          "delete": {
-            "label": "Eliminar",
-            "loading": "Eliminando...",
-            "confirm": {
-              "title": "Eliminar Ubicación",
-              "description": "¿Estás seguro de que quieres eliminar la ubicación {name}? Esta acción no se puede deshacer."
-            }
-          }
-        },
-				"error": {
-					"loading": "Error al cargar ubicaciones: {message}"
-				}
-			}
-		},
-		"growingUnits": {
-			"list": {
-				"title": "Unidades de Cultivo",
-				"description": "Visualiza y gestiona tus espacios de cultivo de manera eficiente.",
-				"empty": "No hay unidades de cultivo disponibles",
-				"search": {
-					"placeholder": "Buscar por nombre, tipo o planta..."
-				},
-				"filters": {
-					"all": "Todo",
-					"indoor": "Interior",
-					"outdoor": "Exterior",
-					"pots": "Macetas",
-					"beds": "Bancales"
-				},
-				"actions": {
-					"create": {
-						"button": "Nueva Unidad",
-						"title": "Crear Unidad de Cultivo",
-						"description": "Agrega una nueva unidad de cultivo para tus plantas",
-						"submit": "Crear",
-						"loading": "Creando..."
-					}
-				},
-				"noPlants": "Sin plantas activas",
-				"common": {
-					"noDimensions": "Sin dimensiones"
-				}
-			},
-			"detail": {
-				"title": "Detalle de Unidad de Cultivo",
-				"notFound": "Unidad de cultivo no encontrada",
-				"error": {
-					"loading": "Error al cargar unidad de cultivo: {message}"
-				},
-				"breadcrumbs": {
-					"home": "Inicio",
-					"growingUnits": "Mis Unidades"
-				},
-				"location": {
-					"label": "Ubicación"
-				},
-				"summary": {
-					"substrate": {
-						"label": "Sustrato",
-						"value": "Tierra Universal"
-					},
-					"exposure": {
-						"label": "Exposición",
-						"directSun": "Sol Directo",
-						"partialSun": "Sol Parcial",
-						"shade": "Sombra"
-					},
-					"lastWatering": {
-						"label": "Último Riego",
-						"today": "Hoy",
-						"yesterday": "Ayer",
-						"never": "Nunca"
-					},
-					"occupancy": {
-						"label": "Ocupación"
-					}
-				},
-				"sections": {
-					"plants": {
-						"title": "Plantas en cultivo",
-						"variety": "Variedad",
-						"planted": "PLANTADO",
-						"days": "días",
-						"manage": "Gestionar"
-					},
-					"history": {
-						"title": "Historial Reciente"
-					}
-				},
-				"actions": {
-					"editUnit": "Editar Unidad",
-					"addPlant": "Agregar Planta",
-					"update": {
-						"title": "Actualizar Unidad de Cultivo",
-						"description": "Actualizar información de la unidad de cultivo",
-						"submit": "Actualizar",
-						"loading": "Actualizando..."
-					},
-					"delete": {
-						"label": "Eliminar",
-						"loading": "Eliminando...",
-						"confirm": {
-							"title": "Eliminar Unidad de Cultivo",
-							"description": "¿Estás seguro de que quieres eliminar la unidad de cultivo {name}? Esta acción no se puede deshacer."
-						}
-					}
-				},
-				"fields": {
-					"name": {
-						"label": "Nombre",
-						"placeholder": "Nombre de la unidad de cultivo"
-					},
-					"type": {
-						"label": "Tipo",
-						"placeholder": "Selecciona el tipo"
-					},
-					"capacity": {
-						"label": "Capacidad",
-						"placeholder": "Número de plantas"
-					},
-					"remainingCapacity": {
-						"label": "Capacidad Restante"
-					},
-					"volume": {
-						"label": "Volumen"
-					},
-					"dimensions": {
-						"label": "Dimensiones"
-					},
-					"length": {
-						"label": "Longitud",
-						"placeholder": "Longitud"
-					},
-					"width": {
-						"label": "Ancho",
-						"placeholder": "Ancho"
-					},
-					"height": {
-						"label": "Altura",
-						"placeholder": "Altura"
-					},
-					"unit": {
-						"label": "Unidad",
-						"placeholder": "Selecciona la unidad"
-					},
-					"plants": {
-						"label": "Plantas activas"
-					}
-				},
-				"types": {
-					"POT": "Maceta",
-					"GARDEN_BED": "Cama de jardín",
-					"HANGING_BASKET": "Cesta colgante",
-					"WINDOW_BOX": "Jardín de ventana"
-				},
-				"units": {
-					"MILLIMETER": "Milímetro",
-					"CENTIMETER": "Centímetro",
-					"METER": "Metro",
-					"INCH": "Pulgada",
-					"FOOT": "Pie"
-				},
-				"validation": {
-					"type": {
-						"invalid": "Tipo inválido"
-					},
-					"capacity": {
-						"required": "La capacidad es requerida"
-					}
-				}
-			}
-		}
-	},
-	"plants": {
-		"actions": {
-			"create": {
-				"title": "Crear Planta",
-				"description": "Agrega una nueva planta a tu colección"
-			}
-		}
-	},
-	"plant": {
-		"fields": {
-			"plantedDate": {
-				"label": "Fecha de Plantación"
-			}
-		}
-	},
-	"legacy": {
-		"plant": {
-			"common": {
-				"notSet": "No establecido",
-				"unnamed": "Planta sin nombre"
-			},
-			"notFound": "Planta no encontrada",
-			"error": {
-				"loading": "Error al cargar planta: {message}"
-			},
-			"fields": {
-				"name": {
-					"label": "Nombre",
-					"placeholder": "Nombre de la planta"
-				},
-				"species": {
-					"label": "Especie",
-					"placeholder": "Especie de la planta"
-				},
-				"plantedDate": {
-					"label": "Fecha de plantación"
-				},
-				"notes": {
-					"label": "Notas",
-					"placeholder": "Notas adicionales sobre la planta"
-				},
-				"status": {
-					"label": "Estado",
-					"placeholder": "Selecciona el estado"
-				},
-				"growingUnitId": {
-					"label": "ID de Unidad de Cultivo"
-				},
-				"sourceGrowingUnitId": {
-					"label": "Unidad de Cultivo Origen",
-					"placeholder": "ID de unidad de cultivo origen"
-				},
-				"targetGrowingUnitId": {
-					"label": "Unidad de Cultivo Destino",
-					"placeholder": "ID de unidad de cultivo destino"
-				}
-			},
-			"status": {
-				"PLANTED": "Plantada",
-				"GROWING": "Creciendo",
-				"HARVESTED": "Cosechada",
-				"DEAD": "Muerta",
-				"ARCHIVED": "Archivada"
-			},
-			"sections": {
-				"info": {
-					"title": "Información de la Planta",
-					"description": "Información detallada sobre la planta"
-				},
-				"update": {
-					"title": "Actualizar Planta",
-					"description": "Actualizar información de la planta"
-				},
-				"transplant": {
-					"title": "Trasplantar Planta",
-					"description": "Mover planta a una unidad de cultivo diferente"
-				}
-			},
-			"actions": {
-				"update": {
-					"label": "Actualizar Planta",
-					"loading": "Actualizando..."
-				},
-				"transplant": {
-					"label": "Trasplantar",
-					"loading": "Trasplantando..."
-				}
-			},
-			"transplant": {
-				"title": "Trasplantar Planta",
-				"description": "Mueve esta planta a una unidad de cultivo diferente",
-				"fields": {
-					"sourceGrowingUnit": {
-						"label": "Desde",
-						"unknown": "Unidad de cultivo desconocida",
-						"helper": "Unidad de cultivo actual (no se puede cambiar)"
-					},
-					"targetGrowingUnitId": {
-						"label": "Hacia",
-						"placeholder": "Selecciona una unidad de cultivo destino",
-						"required": "Debes seleccionar una unidad de cultivo destino",
-						"capacityAvailable": "espacios disponibles"
-					}
-				},
-				"actions": {
-					"submit": {
-						"label": "Trasplantar",
-						"loading": "Trasplantando..."
-					}
-				}
-			},
-			"validation": {
-				"id": {
-					"required": "El ID es requerido"
-				},
-				"plantId": {
-					"required": "El ID de la planta es requerido"
-				},
-				"sourceGrowingUnitId": {
-					"required": "El ID de la unidad de cultivo origen es requerido"
-				},
-				"targetGrowingUnitId": {
-					"required": "El ID de la unidad de cultivo destino es requerido"
-				}
-			},
-			"detail": {
-				"image": {
-					"placeholder": "Imagen de la planta"
-				},
-				"location": {
-					"indoor": "INTERIOR",
-					"outdoor": "EXTERIOR"
-				},
-				"actions": {
-					"registerWatering": "Registrar Riego",
-					"fertilize": "Fertilizar"
-				},
-				"metrics": {
-					"title": "Requisitos de Cuidado",
-					"watering": {
-						"label": "RIEGO",
-						"every7Days": "Cada 7 días"
-					},
-					"light": {
-						"label": "LUZ",
-						"indirect": "Indirecta"
-					},
-					"temperature": {
-						"label": "TEMP"
-					},
-					"humidity": {
-						"label": "HUMEDAD",
-						"high": "Alta"
-					}
-				},
-				"currentStatus": {
-					"lastWatering": {
-						"label": "Último Riego",
-						"onTime": "A tiempo",
-						"daysAgo": "Hace {days} días",
-						"next": "Próximo",
-						"tomorrow": "Mañana"
-					},
-					"lastFertilization": {
-						"label": "Última Fertilización",
-						"pending": "Pendiente",
-						"monthAgo": "Hace {months} mes{months, plural, =1 {} other {es}}",
-						"suggested": "Sugerido",
-						"today": "Hoy"
-					},
-					"plantingDate": {
-						"label": "Fecha de Plantación",
-						"age": "Edad"
-					}
-				},
-				"age": {
-					"yearsMonths": "{years} año {months} meses",
-					"years": "{years} año",
-					"months": "{months} meses",
-					"days": "{days} días"
-				},
-				"personalNotes": {
-					"title": "Notas Personales",
-					"edit": "Editar Notas",
-					"empty": "Aún no hay notas personales. ¡Agrega algunas notas sobre tu rutina de cuidado de plantas!"
-				},
-				"upcomingCare": {
-					"title": "Próximos Cuidados",
-					"tomorrow": "MAÑANA",
-					"lightWatering": "Riego Ligero",
-					"in5Days": "EN 5 DÍAS",
-					"cleanLeaves": "Limpiar Hojas",
-					"duringDay": "Durante el día",
-					"in2Weeks": "EN 2 SEMANAS",
-					"fertilization": "Fertilización",
-					"spring": "Primavera"
-				},
-				"recentHistory": {
-					"title": "Historial Reciente",
-					"viewAll": "Ver todo",
-					"today": "Hoy",
-					"watering": "Riego",
-					"wateringDetails": "250ml de agua filtrada",
-					"pruning": "Poda",
-					"pruningDetails": "Hojas amarillas inferiores",
-					"fertilization": "Fertilización",
-					"fertilizationDetails": "Fertilizante líquido NPK 20-20-20",
-					"completed": "Completado",
-					"table": {
-						"date": "FECHA",
-						"action": "ACCIÓN",
-						"details": "DETALLES",
-						"status": "ESTADO"
-					}
-				},
-				"progressGallery": {
-					"title": "Galería de Progreso",
-					"more": "más"
-				},
-				"wiki": {
-					"title": "Wiki Planta",
-					"didYouKnow": "Sabías que...",
-					"description": "La Monstera Deliciosa también es conocida como 'Costilla de Adán' debido a la forma única de sus hojas que desarrollan agujeros naturales (fenestraciones) a medida que maduran.",
-					"readMore": "LEER MÁS"
-				}
-			}
-		},
-		"plants": {
-			"title": "Lista de Plantas",
-			"description": "Gestiona tu colección botánica y monitorea su salud",
-			"empty": {
-				"default": "No hay plantas registradas",
-				"filtered": "No hay plantas que coincidan con los filtros actuales"
-			},
-			"growingUnit": {
-				"plantCount": "{count} de {total} plantas"
-			},
-			"search": {
-				"placeholder": "Buscar por nombre, especie o ubicación..."
-			},
-			"filters": {
-				"all": "Todas",
-				"indoor": "Interior",
-				"outdoor": "Exterior",
-				"needsWater": "Necesita Agua",
-				"healthy": "Saludables"
-			},
-			"table": {
-				"columns": {
-					"plant": "PLANTA / ESPECIE",
-					"location": "UBICACIÓN",
-					"status": "ESTADO",
-					"lastWatering": "ÚLTIMO RIEGO",
-					"actions": "ACCIONES"
-				},
-				"lastWatering": {
-					"today": "Hoy",
-					"yesterday": "Ayer",
-					"daysAgo": "Hace {days} días",
-					"weeksAgo": "Hace {weeks} semanas"
-				},
-				"pagination": {
-					"showing": "Mostrando {from} a {to} de {total} plantas"
-				}
-			},
-			"actions": {
-				"create": {
-					"button": "Añadir Planta",
-					"title": "Crear Planta",
-					"description": "Agrega una nueva planta a tu colección",
-					"submit": "Crear",
-					"loading": "Creando..."
-				},
-				"view": "Ver",
-				"edit": "Editar",
-				"delete": "Eliminar"
-			},
-			"pagination": {
-				"info": "Página {page} de {totalPages} ({total} en total)"
-			}
-		},
-		"growingUnit": {
-			"page": {
-				"title": "Unidades de Cultivo",
-				"description": "Visualiza y gestiona tus espacios de cultivo de manera eficiente."
-			},
-			"common": {
-				"noDimensions": "Sin dimensiones",
-				"more": "más"
-			},
-			"error": {
-				"loading": "Error al cargar unidades de cultivo: {message}"
-			},
-			"search": {
-				"placeholder": "Buscar por nombre, tipo o planta..."
-			},
-			"filters": {
-				"all": "Todo",
-				"indoor": "Interior",
-				"outdoor": "Exterior",
-				"pots": "Macetas",
-				"beds": "Bancales"
-			},
-			"fields": {
-				"name": {
-					"label": "Nombre",
-					"placeholder": "Nombre de la unidad de cultivo"
-				},
-				"type": {
-					"label": "Tipo",
-					"placeholder": "Selecciona el tipo"
-				},
-				"capacity": {
-					"label": "Capacidad",
-					"placeholder": "Número de plantas"
-				},
-				"remainingCapacity": {
-					"label": "Capacidad Restante"
-				},
-				"volume": {
-					"label": "Volumen"
-				},
-				"dimensions": {
-					"label": "Dimensiones"
-				},
-				"length": {
-					"label": "Longitud",
-					"placeholder": "Longitud"
-				},
-				"width": {
-					"label": "Ancho",
-					"placeholder": "Ancho"
-				},
-				"height": {
-					"label": "Altura",
-					"placeholder": "Altura"
-				},
-				"unit": {
-					"label": "Unidad",
-					"placeholder": "Selecciona la unidad"
-				},
-				"plants": {
-					"label": "Plantas activas"
-				},
-				"createdAt": {
-					"label": "Fecha de creación"
-				}
-			},
-			"noPlants": "Sin plantas activas",
-			"detail": {
-				"notFound": "Unidad de cultivo no encontrada",
-				"error": {
-					"loading": "Error al cargar unidad de cultivo: {message}"
-				},
-				"breadcrumbs": {
-					"home": "Inicio",
-					"growingUnits": "Mis Unidades"
-				},
-				"status": {
-					"active": "ACTIVA",
-					"inactive": "INACTIVA"
-				},
-				"location": {
-					"label": "Ubicación",
-					"indoor": "Interior",
-					"outdoor": "Exterior"
-				},
-				"summary": {
-					"substrate": {
-						"label": "Sustrato",
-						"value": "Tierra Universal"
-					},
-					"exposure": {
-						"label": "Exposición",
-						"directSun": "Sol Directo",
-						"partialSun": "Sol Parcial",
-						"shade": "Sombra"
-					},
-					"lastWatering": {
-						"label": "Último Riego",
-						"today": "Hoy",
-						"yesterday": "Ayer",
-						"never": "Nunca"
-					},
-					"occupancy": {
-						"label": "Ocupación"
-					}
-				},
-				"plants": {
-					"title": "Plantas en cultivo",
-					"viewAll": "Ver todas",
-					"variety": "Variedad",
-					"planted": "PLANTADO",
-					"days": "días",
-					"manage": "Gestionar"
-				},
-				"history": {
-					"title": "Historial Reciente",
-					"viewAll": "Ver todo el historial",
-					"today": "HOY",
-					"yesterday": "AYER"
-				},
-				"actions": {
-					"editUnit": "Editar Unidad",
-					"addPlant": "Agregar Planta"
-				}
-			},
-			"type": {
-				"POT": "Maceta",
-				"GARDEN_BED": "Cama de jardín",
-				"HANGING_BASKET": "Cesta colgante",
-				"WINDOW_BOX": "Jardín de ventana"
-			},
-			"unit": {
-				"MILLIMETER": "Milímetro",
-				"CENTIMETER": "Centímetro",
-				"METER": "Metro",
-				"INCH": "Pulgada",
-				"FOOT": "Pie"
-			},
-			"actions": {
-				"create": {
-					"title": "Crear Unidad de Cultivo",
-					"description": "Agrega una nueva unidad de cultivo para tus plantas",
-					"button": "Nueva Unidad",
-					"submit": "Crear",
-					"loading": "Creando..."
-				},
-				"update": {
-					"title": "Actualizar Unidad de Cultivo",
-					"description": "Actualizar información de la unidad de cultivo",
-					"submit": "Actualizar",
-					"loading": "Actualizando..."
-				},
-				"edit": "Editar",
-				"delete": {
-					"label": "Eliminar",
-					"loading": "Eliminando...",
-					"confirm": {
-						"title": "Eliminar Unidad de Cultivo",
-						"description": "¿Estás seguro de que quieres eliminar la unidad de cultivo {name}? Esta acción no se puede deshacer."
-					}
-				}
-			},
-			"pagination": {
-				"info": "Página {page} de {totalPages} ({total} en total)"
-			},
-			"validation": {
-				"id": {
-					"required": "El ID es requerido"
-				},
-				"name": {
-					"required": "El nombre es requerido"
-				},
-				"type": {
-					"invalid": "Tipo inválido"
-				},
-				"capacity": {
-					"required": "La capacidad es requerida"
-				}
-			}
-		},
-		"user": {
-			"loading": "Cargando usuario...",
-			"notFound": "Usuario no encontrado",
-			"validation": {
-				"species": {
-					"required": "La especie es requerida"
-				},
-				"status": {
-					"invalid": "Estado inválido"
-				},
-				"growingUnitId": {
-					"required": "El ID de la unidad de cultivo es requerido"
-				}
-			}
-		},
-		"authPage": {
-			"title": {
-				"login": "Bienvenido de nuevo",
-				"signup": "Crear una cuenta"
-			},
-			"description": {
-				"login": "Ingresa tu email y contraseña para iniciar sesión",
-				"signup": "Ingresa tu información para crear una nueva cuenta"
-			},
-			"fields": {
-				"email": {
-					"label": "Email",
-					"placeholder": "nombre@ejemplo.com"
-				},
-				"password": {
-					"label": "Contraseña",
-					"placeholder": {
-						"login": "Ingresa tu contraseña",
-						"signup": "Al menos 8 caracteres"
-					}
-				},
-				"confirmPassword": {
-					"label": "Confirmar contraseña",
-					"placeholder": "Confirma tu contraseña"
-				}
-			},
-			"actions": {
-				"login": "Iniciar sesión",
-				"signup": "Crear cuenta",
-				"switchToSignup": "Registrarse",
-				"switchToLogin": "Iniciar sesión",
-				"loading": {
-					"login": "Iniciando sesión...",
-					"signup": "Creando cuenta..."
-				}
-			},
-			"messages": {
-				"switchToSignup": "¿No tienes una cuenta?",
-				"switchToLogin": "¿Ya tienes una cuenta?",
-				"error": "Ocurrió un error. Por favor intenta de nuevo."
-			},
-			"validation": {
-				"email": {
-					"required": "El email es requerido",
-					"invalid": "Formato de email inválido"
-				},
-				"password": {
-					"required": "La contraseña es requerida",
-					"minLength": "La contraseña debe tener al menos 8 caracteres"
-				},
-				"confirmPassword": {
-					"required": "Por favor confirma tu contraseña",
-					"mismatch": "Las contraseñas no coinciden"
-				}
-			}
-		}
-	}
+  "common": {
+    "loading": "Cargando...",
+    "error": "Error",
+    "unknown": "Desconocido",
+    "cancel": "Cancelar",
+    "delete": "Eliminar",
+    "edit": "Editar",
+    "view": "Ver",
+    "create": "Crear",
+    "update": "Actualizar",
+    "submit": "Enviar",
+    "save": "Guardar",
+    "close": "Cerrar",
+    "back": "Volver",
+    "next": "Siguiente",
+    "previous": "Anterior",
+    "search": "Buscar",
+    "filter": "Filtrar",
+    "all": "Todos",
+    "none": "Ninguno",
+    "empty": "Vacío",
+    "notSet": "No establecido",
+    "notFound": "No encontrado",
+    "today": "Hoy",
+    "yesterday": "Ayer",
+    "tomorrow": "Mañana",
+    "completed": "Completado",
+    "pending": "Pendiente",
+    "viewAll": "Ver todo",
+    "seeAll": "Ver todas"
+  },
+  "nav": {
+    "home": "Inicio",
+    "settings": "Configuración",
+    "plants": "Plantas",
+    "growingUnits": "Unidades de Cultivo",
+    "locations": "Ubicaciones",
+    "search": "Buscar",
+    "searchPlaceholder": "Buscar..."
+  },
+  "fields": {
+    "name": {
+      "label": "Nombre",
+      "placeholder": "Ingresa el nombre"
+    },
+    "status": {
+      "label": "Estado",
+      "placeholder": "Selecciona el estado"
+    },
+    "createdAt": {
+      "label": "Fecha de creación"
+    },
+    "updatedAt": {
+      "label": "Fecha de actualización"
+    },
+    "type": {
+      "label": "Tipo",
+      "placeholder": "Selecciona el tipo"
+    },
+    "locationId": {
+      "label": "Ubicación",
+      "placeholder": "Selecciona una ubicación"
+    },
+    "capacity": {
+      "label": "Capacidad",
+      "placeholder": "Número de elementos"
+    },
+    "remainingCapacity": {
+      "label": "Capacidad Restante"
+    },
+    "volume": {
+      "label": "Volumen"
+    },
+    "dimensions": {
+      "label": "Dimensiones"
+    },
+    "length": {
+      "label": "Longitud",
+      "placeholder": "Longitud"
+    },
+    "width": {
+      "label": "Ancho",
+      "placeholder": "Ancho"
+    },
+    "height": {
+      "label": "Altura",
+      "placeholder": "Altura"
+    },
+    "unit": {
+      "label": "Unidad",
+      "placeholder": "Selecciona la unidad"
+    },
+    "plants": {
+      "label": "Plantas activas"
+    },
+    "species": {
+      "label": "Especie",
+      "placeholder": "Especie"
+    },
+    "plantedDate": {
+      "label": "Fecha de plantación"
+    },
+    "notes": {
+      "label": "Notas",
+      "placeholder": "Notas adicionales"
+    },
+    "description": {
+      "label": "Descripción",
+      "placeholder": "Ingresa la descripción"
+    },
+    "growingUnitId": {
+      "label": "Unidad de Cultivo"
+    }
+  },
+  "types": {
+    "growingUnit": {
+      "POT": "Maceta",
+      "GARDEN_BED": "Cama de jardín",
+      "HANGING_BASKET": "Cesta colgante",
+      "WINDOW_BOX": "Jardín de ventana"
+    },
+    "location": {
+      "ROOM": "Habitación",
+      "BALCONY": "Balcón",
+      "GARDEN": "Jardín",
+      "GREENHOUSE": "Invernadero",
+      "OUTDOOR_SPACE": "Espacio Exterior",
+      "INDOOR_SPACE": "Espacio Interior"
+    }
+  },
+  "units": {
+    "length": {
+      "MILLIMETER": "Milímetro",
+      "CENTIMETER": "Centímetro",
+      "METER": "Metro",
+      "INCH": "Pulgada",
+      "FOOT": "Pie"
+    }
+  },
+  "status": {
+    "plant": {
+      "PLANTED": "Plantada",
+      "GROWING": "Creciendo",
+      "HARVESTED": "Cosechada",
+      "DEAD": "Muerta",
+      "ARCHIVED": "Archivada"
+    },
+    "growingUnit": {
+      "active": "ACTIVA",
+      "inactive": "INACTIVA"
+    },
+    "location": {
+      "indoor": "Interior",
+      "outdoor": "Exterior"
+    }
+  },
+  "validation": {
+    "required": "Este campo es requerido",
+    "invalid": "Valor inválido",
+    "id": {
+      "required": "El ID es requerido"
+    },
+    "name": {
+      "required": "El nombre es requerido"
+    },
+    "type": {
+      "invalid": "Tipo inválido"
+    },
+    "locationId": {
+      "required": "La ubicación es requerida"
+    },
+    "capacity": {
+      "required": "La capacidad es requerida"
+    },
+    "unit": {
+      "invalid": "Unidad inválida"
+    }
+  },
+  "pagination": {
+    "info": "Página {page} de {totalPages} ({total} en total)",
+    "showing": "Mostrando {from} a {to} de {total}"
+  },
+  "time": {
+    "daysAgo": "Hace {days} días",
+    "weeksAgo": "Hace {weeks} semanas",
+    "monthsAgo": "Hace {months} mes{months, plural, =1 {} other {es}}",
+    "yearsAgo": "Hace {years} años"
+  }
 }


### PR DESCRIPTION
## Summary

Refactors the i18n structure to organize translations by feature, replacing monolithic locale files with feature-specific translation files.

## Changes

- Split monolithic locale files into feature-specific translation files
- Create locale directories under each feature (plants, growing-units, locations, auth, users, dashboard)
- Update shared locales to contain only common/reusable translations
- Update i18n request config to load and merge translations from all features
- Update 49 component files to use new translation key paths (pages.* → features.*)

## Benefits

- ✅ Better organization with translations grouped by feature
- ✅ Easier maintenance with smaller, focused files
- ✅ Improved scalability for adding new features
- ✅ Co-location of translations with feature code
- ✅ Reduced merge conflicts with parallel development

Closes #153

---
Generated with [Claude Code](https://claude.ai/code)) | [View job run](https://github.com/sisques-labs/greenhub/actions/runs/21800718583) | [Branch: claude/issue-153-20260208-1535](https://github.com/sisques-labs/greenhub/tree/claude/issue-153-20260208-1535