### PR TITLE
feat(web): Plant Species Context - Page Hooks

### DIFF
--- a/apps/web/features/plant-species/hooks/pages/usePlantSpeciesDetailPage.ts
+++ b/apps/web/features/plant-species/hooks/pages/usePlantSpeciesDetailPage.ts
@@ -31,7 +31,7 @@ export function usePlantSpeciesDetailPage(id: string) {
 	);
 
 	const handleUpdateSpecies = useCallback(
-		async (data: PlantSpeciesUpdateInput) => {
+		async (data: Omit<PlantSpeciesUpdateInput, 'id'>) => {
 			await handleUpdate(
 				{ id, ...data },
 				() => {

--- a/apps/web/features/plant-species/hooks/pages/usePlantSpeciesDetailPage.ts
+++ b/apps/web/features/plant-species/hooks/pages/usePlantSpeciesDetailPage.ts
@@ -1,0 +1,72 @@
+'use client';
+
+import type { PlantSpeciesUpdateInput } from '@/features/plant-species/api/types/plant-species-request.types';
+import { usePlantSpeciesDelete } from '@/features/plant-species/hooks/use-plant-species-delete/use-plant-species-delete';
+import { usePlantSpeciesFindById } from '@/features/plant-species/hooks/use-plant-species-find-by-id/use-plant-species-find-by-id';
+import { usePlantSpeciesUpdate } from '@/features/plant-species/hooks/use-plant-species-update/use-plant-species-update';
+import { useRouter } from 'next/navigation';
+import { useCallback, useState } from 'react';
+import { toast } from 'sonner';
+
+/**
+ * Hook that provides all the logic for the plant species detail page
+ * Centralizes state management, data fetching, and event handlers
+ */
+export function usePlantSpeciesDetailPage(id: string) {
+	const router = useRouter();
+	const { plantSpecies, isLoading, error } = usePlantSpeciesFindById(id);
+
+	const {
+		handleUpdate,
+		isLoading: isUpdating,
+	} = usePlantSpeciesUpdate();
+
+	const {
+		handleDelete,
+		isLoading: isDeleting,
+	} = usePlantSpeciesDelete();
+
+	const [activeTab, setActiveTab] = useState<'overview' | 'care' | 'growth'>(
+		'overview',
+	);
+
+	const handleUpdateSpecies = useCallback(
+		async (data: PlantSpeciesUpdateInput) => {
+			await handleUpdate(
+				{ id, ...data },
+				() => {
+					toast.success('Species updated successfully');
+				},
+				() => {
+					toast.error('Failed to update species');
+				},
+			);
+		},
+		[id, handleUpdate],
+	);
+
+	const handleDeleteSpecies = useCallback(async () => {
+		await handleDelete(
+			id,
+			() => {
+				toast.success('Species deleted successfully');
+				router.push('/plant-species');
+			},
+			() => {
+				toast.error('Failed to delete species');
+			},
+		);
+	}, [id, handleDelete, router]);
+
+	return {
+		plantSpecies,
+		isLoading,
+		error,
+		activeTab,
+		setActiveTab,
+		handleUpdate: handleUpdateSpecies,
+		handleDelete: handleDeleteSpecies,
+		isUpdating,
+		isDeleting,
+	};
+}

--- a/apps/web/features/plant-species/hooks/pages/usePlantSpeciesListPage.ts
+++ b/apps/web/features/plant-species/hooks/pages/usePlantSpeciesListPage.ts
@@ -1,0 +1,83 @@
+'use client';
+
+import type {
+	PlantSpeciesCategory,
+	PlantSpeciesDifficulty,
+} from '@/features/plant-species/api/types/plant-species.types';
+import { usePlantSpeciesFindByCriteria } from '@/features/plant-species/hooks/use-plant-species-find-by-criteria/use-plant-species-find-by-criteria';
+import { useCallback, useMemo, useState } from 'react';
+
+interface PlantSpeciesFilters {
+	category: PlantSpeciesCategory | undefined;
+	difficulty: PlantSpeciesDifficulty | undefined;
+	search: string;
+	verifiedOnly: boolean;
+}
+
+/**
+ * Hook that provides all the logic for the plant species list page
+ * Centralizes state management, data fetching, filtering, and event handlers
+ */
+export function usePlantSpeciesListPage() {
+	const [filters, setFilters] = useState<PlantSpeciesFilters>({
+		category: undefined,
+		difficulty: undefined,
+		search: '',
+		verifiedOnly: false,
+	});
+
+	const [viewMode, setViewMode] = useState<'grid' | 'table'>('grid');
+
+	const { plantSpecies, isLoading, error } = usePlantSpeciesFindByCriteria();
+
+	const filteredSpecies = useMemo(() => {
+		if (!plantSpecies) return [];
+
+		return plantSpecies.items.filter((s) => {
+			if (filters.category && s.category !== filters.category) return false;
+			if (filters.difficulty && s.difficulty !== filters.difficulty)
+				return false;
+			if (filters.verifiedOnly && !s.isVerified) return false;
+			if (filters.search) {
+				const searchLower = filters.search.toLowerCase();
+				return (
+					s.commonName.toLowerCase().includes(searchLower) ||
+					s.scientificName.toLowerCase().includes(searchLower) ||
+					(s.family?.toLowerCase().includes(searchLower) ?? false)
+				);
+			}
+			return true;
+		});
+	}, [plantSpecies, filters]);
+
+	const handleFilterChange = useCallback(
+		<K extends keyof PlantSpeciesFilters>(
+			key: K,
+			value: PlantSpeciesFilters[K],
+		) => {
+			setFilters((prev) => ({ ...prev, [key]: value }));
+		},
+		[],
+	);
+
+	const handleClearFilters = useCallback(() => {
+		setFilters({
+			category: undefined,
+			difficulty: undefined,
+			search: '',
+			verifiedOnly: false,
+		});
+	}, []);
+
+	return {
+		species: filteredSpecies,
+		isLoading,
+		error,
+		filters,
+		setFilters,
+		handleFilterChange,
+		handleClearFilters,
+		viewMode,
+		setViewMode,
+	};
+}


### PR DESCRIPTION
Implements the plant species page hooks as described in issue #171.

## Changes

- `usePlantSpeciesListPage`: manages filters, view mode, and client-side filtering
- `usePlantSpeciesDetailPage`: manages active tab, update/delete operations with toast notifications

Closes #171

Generated with [Claude Code](https://claude.ai/code)