### PR TITLE
feat(web): Plant Species Context - Organism Components (Forms, Modals, Tables, Cards)

### DIFF
--- a/apps/web/features/plant-species/components/cards/PlantSpeciesCard/PlantSpeciesCard.tsx
+++ b/apps/web/features/plant-species/components/cards/PlantSpeciesCard/PlantSpeciesCard.tsx
@@ -1,0 +1,165 @@
+'use client';
+
+import type { PlantSpeciesResponse } from '@/features/plant-species/api/types/plant-species-response.types';
+import { PLANT_SPECIES_CATEGORIES } from '@/features/plant-species/constants/plant-species-categories';
+import { PLANT_SPECIES_DIFFICULTY } from '@/features/plant-species/constants/plant-species-difficulty';
+import { PLANT_SPECIES_LIGHT_REQUIREMENTS } from '@/features/plant-species/constants/plant-species-requirements';
+import { Badge } from '@/shared/components/ui/badge';
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle,
+} from '@/shared/components/ui/card';
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuTrigger,
+} from '@/shared/components/ui/dropdown-menu';
+import { MoreVerticalIcon } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+
+interface PlantSpeciesCardProps {
+	plantSpecies: PlantSpeciesResponse;
+	onView?: (plantSpecies: PlantSpeciesResponse) => void;
+	onEdit?: (plantSpecies: PlantSpeciesResponse) => void;
+	onDelete?: (id: string) => void;
+}
+
+export function PlantSpeciesCard({
+	plantSpecies,
+	onView,
+	onEdit,
+	onDelete,
+}: PlantSpeciesCardProps) {
+	const t = useTranslations();
+
+	const categoryInfo = PLANT_SPECIES_CATEGORIES[plantSpecies.category];
+	const difficultyInfo = PLANT_SPECIES_DIFFICULTY[plantSpecies.difficulty];
+	const lightInfo = PLANT_SPECIES_LIGHT_REQUIREMENTS[plantSpecies.lightRequirements];
+
+	const handleActionClick = (e: React.MouseEvent) => {
+		e.stopPropagation();
+	};
+
+	const handleEdit = (e: React.MouseEvent) => {
+		e.stopPropagation();
+		onEdit?.(plantSpecies);
+	};
+
+	const handleDelete = (e: React.MouseEvent) => {
+		e.stopPropagation();
+		onDelete?.(plantSpecies.id);
+	};
+
+	const handleCardClick = () => {
+		onView?.(plantSpecies);
+	};
+
+	return (
+		<Card
+			className="hover:shadow-lg transition-shadow overflow-hidden pt-0! cursor-pointer"
+			onClick={handleCardClick}
+		>
+			<CardHeader className="p-0! m-0!">
+				{/* Image area with badge and menu */}
+				<div className="relative w-full h-48 bg-muted">
+					<div className="w-full h-full flex items-center justify-center text-5xl">
+						{categoryInfo.icon}
+					</div>
+
+					{/* Category badge - top-left */}
+					<div className="absolute top-2 left-2">
+						<Badge variant="secondary" className="text-xs">
+							{categoryInfo.label}
+						</Badge>
+					</div>
+
+					{/* Verified badge - top-left below category */}
+					{plantSpecies.isVerified && (
+						<div className="absolute top-8 left-2 mt-1">
+							<Badge variant="default" className="text-xs">
+								{t('features.plantSpecies.verified')}
+							</Badge>
+						</div>
+					)}
+
+					{/* Actions menu - top-right */}
+					{(onEdit || onDelete) && (
+						<div className="absolute top-2 right-2" onClick={handleActionClick}>
+							<DropdownMenu>
+								<DropdownMenuTrigger asChild>
+									<button className="h-8 w-8 inline-flex items-center justify-center rounded-md hover:bg-accent bg-background/80 backdrop-blur-sm">
+										<MoreVerticalIcon className="h-4 w-4" />
+									</button>
+								</DropdownMenuTrigger>
+								<DropdownMenuContent align="end">
+									{onView && (
+										<DropdownMenuItem
+											onClick={(e) => {
+												e.stopPropagation();
+												onView(plantSpecies);
+											}}
+										>
+											{t('features.plantSpecies.list.actions.view')}
+										</DropdownMenuItem>
+									)}
+									{onEdit && (
+										<DropdownMenuItem onClick={handleEdit}>
+											{t('features.plantSpecies.list.actions.edit')}
+										</DropdownMenuItem>
+									)}
+									{onDelete && (
+										<DropdownMenuItem
+											onClick={handleDelete}
+											className="text-destructive"
+										>
+											{t('features.plantSpecies.list.actions.delete.label')}
+										</DropdownMenuItem>
+									)}
+								</DropdownMenuContent>
+							</DropdownMenu>
+						</div>
+					)}
+				</div>
+
+				<div className="p-4 space-y-1">
+					<CardTitle className="text-base font-bold leading-tight">
+						{plantSpecies.commonName}
+					</CardTitle>
+					<CardDescription className="text-xs italic">
+						{plantSpecies.scientificName}
+					</CardDescription>
+				</div>
+			</CardHeader>
+
+			<CardContent className="pt-0 px-4 pb-4">
+				<div className="flex items-center justify-between text-xs text-muted-foreground">
+					<span>
+						{difficultyInfo.icon} {difficultyInfo.label}
+					</span>
+					<span>
+						{lightInfo.icon} {lightInfo.label}
+					</span>
+				</div>
+
+				{plantSpecies.tags && plantSpecies.tags.length > 0 && (
+					<div className="flex flex-wrap gap-1 mt-2">
+						{plantSpecies.tags.slice(0, 3).map((tag) => (
+							<Badge key={tag} variant="outline" className="text-xs px-1.5 py-0">
+								{tag}
+							</Badge>
+						))}
+						{plantSpecies.tags.length > 3 && (
+							<Badge variant="outline" className="text-xs px-1.5 py-0">
+								+{plantSpecies.tags.length - 3}
+							</Badge>
+						)}
+					</div>
+				)}
+			</CardContent>
+		</Card>
+	);
+}

--- a/apps/web/features/plant-species/components/cards/PlantSpeciesDetailCard/PlantSpeciesDetailCard.tsx
+++ b/apps/web/features/plant-species/components/cards/PlantSpeciesDetailCard/PlantSpeciesDetailCard.tsx
@@ -1,0 +1,281 @@
+'use client';
+
+import type { PlantSpeciesResponse } from '@/features/plant-species/api/types/plant-species-response.types';
+import { PLANT_SPECIES_CATEGORIES } from '@/features/plant-species/constants/plant-species-categories';
+import { PLANT_SPECIES_DIFFICULTY } from '@/features/plant-species/constants/plant-species-difficulty';
+import {
+	PLANT_SPECIES_LIGHT_REQUIREMENTS,
+	PLANT_SPECIES_SOIL_TYPE,
+	PLANT_SPECIES_WATER_REQUIREMENTS,
+} from '@/features/plant-species/constants/plant-species-requirements';
+import {
+	formatGrowthTime,
+	formatMatureSize,
+	formatPhRange,
+	formatTemperatureRange,
+} from '@/features/plant-species/utils/plant-species-formatters';
+import { Badge } from '@/shared/components/ui/badge';
+import { Button } from '@/shared/components/ui/button';
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle,
+} from '@/shared/components/ui/card';
+import { Separator } from '@/shared/components/ui/separator';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/shared/components/ui/tabs';
+import { useTranslations } from 'next-intl';
+
+interface PlantSpeciesDetailCardProps {
+	plantSpecies: PlantSpeciesResponse;
+	onEdit?: (plantSpecies: PlantSpeciesResponse) => void;
+	onDelete?: (id: string) => void;
+}
+
+export function PlantSpeciesDetailCard({
+	plantSpecies,
+	onEdit,
+	onDelete,
+}: PlantSpeciesDetailCardProps) {
+	const t = useTranslations();
+
+	const categoryInfo = PLANT_SPECIES_CATEGORIES[plantSpecies.category];
+	const difficultyInfo = PLANT_SPECIES_DIFFICULTY[plantSpecies.difficulty];
+	const lightInfo = PLANT_SPECIES_LIGHT_REQUIREMENTS[plantSpecies.lightRequirements];
+	const waterInfo = PLANT_SPECIES_WATER_REQUIREMENTS[plantSpecies.waterRequirements];
+
+	return (
+		<Card className="w-full">
+			<CardHeader>
+				<div className="flex items-start justify-between gap-4">
+					<div className="flex items-center gap-4">
+						<div className="h-16 w-16 rounded-lg bg-muted flex items-center justify-center text-4xl shrink-0">
+							{categoryInfo.icon}
+						</div>
+						<div>
+							<CardTitle className="text-2xl">{plantSpecies.commonName}</CardTitle>
+							<CardDescription className="italic text-base mt-0.5">
+								{plantSpecies.scientificName}
+							</CardDescription>
+							{plantSpecies.family && (
+								<p className="text-sm text-muted-foreground mt-1">
+									{t('shared.fields.family.label')}: {plantSpecies.family}
+								</p>
+							)}
+						</div>
+					</div>
+					<div className="flex flex-col gap-2 items-end shrink-0">
+						<Badge variant="secondary">
+							{categoryInfo.icon} {categoryInfo.label}
+						</Badge>
+						{plantSpecies.isVerified && (
+							<Badge variant="default">
+								{t('features.plantSpecies.verified')}
+							</Badge>
+						)}
+						<div className="flex gap-2 mt-2">
+							{onEdit && (
+								<Button
+									variant="outline"
+									size="sm"
+									onClick={() => onEdit(plantSpecies)}
+								>
+									{t('common.edit')}
+								</Button>
+							)}
+							{onDelete && (
+								<Button
+									variant="destructive"
+									size="sm"
+									onClick={() => onDelete(plantSpecies.id)}
+								>
+									{t('common.delete')}
+								</Button>
+							)}
+						</div>
+					</div>
+				</div>
+
+				{plantSpecies.description && (
+					<p className="text-sm text-muted-foreground mt-4">
+						{plantSpecies.description}
+					</p>
+				)}
+			</CardHeader>
+
+			<CardContent>
+				<Tabs defaultValue="care">
+					<TabsList className="mb-4">
+						<TabsTrigger value="care">
+							{t('features.plantSpecies.tabs.care')}
+						</TabsTrigger>
+						<TabsTrigger value="growth">
+							{t('features.plantSpecies.tabs.growth')}
+						</TabsTrigger>
+						<TabsTrigger value="environment">
+							{t('features.plantSpecies.tabs.environment')}
+						</TabsTrigger>
+					</TabsList>
+
+					{/* Care Tab */}
+					<TabsContent value="care" className="space-y-4">
+						<div className="grid grid-cols-2 md:grid-cols-3 gap-4">
+							<div className="p-3 rounded-lg border space-y-1">
+								<div className="text-xs text-muted-foreground">
+									{t('shared.fields.difficulty.label')}
+								</div>
+								<div className="font-medium flex items-center gap-1">
+									<span>{difficultyInfo.icon}</span>
+									<span>{difficultyInfo.label}</span>
+								</div>
+								<div className="text-xs text-muted-foreground">
+									{difficultyInfo.description}
+								</div>
+							</div>
+
+							<div className="p-3 rounded-lg border space-y-1">
+								<div className="text-xs text-muted-foreground">
+									{t('shared.fields.lightRequirements.label')}
+								</div>
+								<div className="font-medium flex items-center gap-1">
+									<span>{lightInfo.icon}</span>
+									<span>{lightInfo.label}</span>
+								</div>
+								<div className="text-xs text-muted-foreground">
+									{lightInfo.description}
+								</div>
+							</div>
+
+							<div className="p-3 rounded-lg border space-y-1">
+								<div className="text-xs text-muted-foreground">
+									{t('shared.fields.waterRequirements.label')}
+								</div>
+								<div className="font-medium flex items-center gap-1">
+									<span>{waterInfo.icon}</span>
+									<span>{waterInfo.label}</span>
+								</div>
+								<div className="text-xs text-muted-foreground">
+									{waterInfo.description}
+								</div>
+							</div>
+
+							{plantSpecies.humidityRequirements && (
+								<div className="p-3 rounded-lg border space-y-1">
+									<div className="text-xs text-muted-foreground">
+										{t('shared.fields.humidityRequirements.label')}
+									</div>
+									<div className="font-medium flex items-center gap-1">
+										<span>💨</span>
+										<span>{plantSpecies.humidityRequirements}</span>
+									</div>
+								</div>
+							)}
+
+							{plantSpecies.soilType && (
+								<div className="p-3 rounded-lg border space-y-1">
+									<div className="text-xs text-muted-foreground">
+										{t('shared.fields.soilType.label')}
+									</div>
+									<div className="font-medium flex items-center gap-1">
+										<span>{PLANT_SPECIES_SOIL_TYPE[plantSpecies.soilType].icon}</span>
+										<span>{PLANT_SPECIES_SOIL_TYPE[plantSpecies.soilType].label}</span>
+									</div>
+									<div className="text-xs text-muted-foreground">
+										{PLANT_SPECIES_SOIL_TYPE[plantSpecies.soilType].description}
+									</div>
+								</div>
+							)}
+						</div>
+					</TabsContent>
+
+					{/* Growth Tab */}
+					<TabsContent value="growth" className="space-y-4">
+						<div className="grid grid-cols-2 md:grid-cols-3 gap-4">
+							<div className="p-3 rounded-lg border space-y-1">
+								<div className="text-xs text-muted-foreground">
+									{t('shared.fields.growthRate.label')}
+								</div>
+								<div className="font-medium">{plantSpecies.growthRate}</div>
+							</div>
+
+							{plantSpecies.growthTime && (
+								<div className="p-3 rounded-lg border space-y-1">
+									<div className="text-xs text-muted-foreground">
+										{t('shared.fields.growthTime.label')}
+									</div>
+									<div className="font-medium">
+										{formatGrowthTime(plantSpecies.growthTime)}
+									</div>
+								</div>
+							)}
+
+							{plantSpecies.matureSize && (
+								<div className="p-3 rounded-lg border space-y-1">
+									<div className="text-xs text-muted-foreground">
+										{t('shared.fields.matureSize.label')}
+									</div>
+									<div className="font-medium">
+										{formatMatureSize(plantSpecies.matureSize)}
+									</div>
+								</div>
+							)}
+						</div>
+					</TabsContent>
+
+					{/* Environment Tab */}
+					<TabsContent value="environment" className="space-y-4">
+						<div className="grid grid-cols-2 gap-4">
+							{plantSpecies.temperatureRange && (
+								<div className="p-3 rounded-lg border space-y-1">
+									<div className="text-xs text-muted-foreground">
+										{t('shared.fields.temperatureRange.label')}
+									</div>
+									<div className="font-medium">
+										{formatTemperatureRange(plantSpecies.temperatureRange)}
+									</div>
+								</div>
+							)}
+
+							{plantSpecies.phRange && (
+								<div className="p-3 rounded-lg border space-y-1">
+									<div className="text-xs text-muted-foreground">
+										{t('shared.fields.phRange.label')}
+									</div>
+									<div className="font-medium">
+										{formatPhRange(plantSpecies.phRange)}
+									</div>
+								</div>
+							)}
+						</div>
+
+						{(!plantSpecies.temperatureRange && !plantSpecies.phRange) && (
+							<div className="text-sm text-muted-foreground text-center py-4">
+								{t('features.plantSpecies.noEnvironmentalData')}
+							</div>
+						)}
+					</TabsContent>
+				</Tabs>
+
+				{/* Tags */}
+				{plantSpecies.tags && plantSpecies.tags.length > 0 && (
+					<>
+						<Separator className="my-4" />
+						<div>
+							<div className="text-sm font-medium mb-2">
+								{t('shared.fields.tags.label')}
+							</div>
+							<div className="flex flex-wrap gap-2">
+								{plantSpecies.tags.map((tag) => (
+									<Badge key={tag} variant="outline">
+										{tag}
+									</Badge>
+								))}
+							</div>
+						</div>
+					</>
+				)}
+			</CardContent>
+		</Card>
+	);
+}

--- a/apps/web/features/plant-species/components/forms/PlantSpeciesCreateForm/PlantSpeciesCreateForm.tsx
+++ b/apps/web/features/plant-species/components/forms/PlantSpeciesCreateForm/PlantSpeciesCreateForm.tsx
@@ -1,0 +1,585 @@
+'use client';
+
+import {
+	PlantSpeciesCategory,
+	PlantSpeciesDifficulty,
+	PlantSpeciesGrowthRate,
+	PlantSpeciesHumidityRequirements,
+	PlantSpeciesLightRequirements,
+	PlantSpeciesSoilType,
+	PlantSpeciesWaterRequirements,
+} from '@/features/plant-species/api/types/plant-species.types';
+import { PLANT_SPECIES_CATEGORIES } from '@/features/plant-species/constants/plant-species-categories';
+import { PLANT_SPECIES_DIFFICULTY } from '@/features/plant-species/constants/plant-species-difficulty';
+import {
+	PLANT_SPECIES_LIGHT_REQUIREMENTS,
+	PLANT_SPECIES_SOIL_TYPE,
+	PLANT_SPECIES_WATER_REQUIREMENTS,
+} from '@/features/plant-species/constants/plant-species-requirements';
+import type { PlantSpeciesCreateFormValues } from '@/features/plant-species/schemas/plant-species-create.schema';
+import { Badge } from '@/shared/components/ui/badge';
+import { Button } from '@/shared/components/ui/button';
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from '@/shared/components/ui/dialog';
+import {
+	Form,
+	FormControl,
+	FormItem,
+	FormLabel,
+	FormMessage,
+} from '@/shared/components/ui/form';
+import { Input } from '@/shared/components/ui/input';
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from '@/shared/components/ui/select';
+import { Textarea } from '@/shared/components/ui/textarea';
+import { XIcon } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+import { usePlantSpeciesCreateForm } from './usePlantSpeciesCreateForm';
+
+interface PlantSpeciesCreateFormProps {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	onSubmit: (values: PlantSpeciesCreateFormValues) => Promise<void>;
+	isLoading: boolean;
+	error: Error | null;
+}
+
+export function PlantSpeciesCreateForm({
+	open,
+	onOpenChange,
+	onSubmit,
+	isLoading,
+	error,
+}: PlantSpeciesCreateFormProps) {
+	const t = useTranslations();
+
+	const {
+		commonName,
+		scientificName,
+		family,
+		description,
+		category,
+		difficulty,
+		growthRate,
+		lightRequirements,
+		waterRequirements,
+		humidityRequirements,
+		soilType,
+		temperatureMin,
+		temperatureMax,
+		phMin,
+		phMax,
+		matureSizeHeight,
+		matureSizeWidth,
+		growthTime,
+		tags,
+		tagInput,
+		formErrors,
+		setCommonName,
+		setScientificName,
+		setFamily,
+		setDescription,
+		setCategory,
+		setDifficulty,
+		setGrowthRate,
+		setLightRequirements,
+		setWaterRequirements,
+		setHumidityRequirements,
+		setSoilType,
+		setTemperatureMin,
+		setTemperatureMax,
+		setPhMin,
+		setPhMax,
+		setMatureSizeHeight,
+		setMatureSizeWidth,
+		setGrowthTime,
+		setTagInput,
+		addTag,
+		removeTag,
+		handleSubmit,
+		handleOpenChange,
+	} = usePlantSpeciesCreateForm({
+		onSubmit,
+		onOpenChange,
+		error,
+		translations: (key: string) => t(key),
+	});
+
+	return (
+		<Dialog open={open} onOpenChange={handleOpenChange}>
+			<DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
+				<DialogHeader>
+					<DialogTitle>
+						{t('features.plantSpecies.list.actions.create.title')}
+					</DialogTitle>
+					<DialogDescription>
+						{t('features.plantSpecies.list.actions.create.description')}
+					</DialogDescription>
+				</DialogHeader>
+				<Form errors={formErrors}>
+					<form onSubmit={handleSubmit} className="space-y-4">
+						{/* Basic Info */}
+						<div className="grid grid-cols-2 gap-4">
+							<FormItem>
+								<FormLabel>{t('shared.fields.commonName.label')}</FormLabel>
+								<FormControl>
+									<Input
+										placeholder={t('shared.fields.commonName.placeholder')}
+										disabled={isLoading}
+										value={commonName}
+										onChange={(e) => setCommonName(e.target.value)}
+									/>
+								</FormControl>
+								<FormMessage fieldName="commonName" />
+							</FormItem>
+
+							<FormItem>
+								<FormLabel>{t('shared.fields.scientificName.label')}</FormLabel>
+								<FormControl>
+									<Input
+										placeholder={t('shared.fields.scientificName.placeholder')}
+										disabled={isLoading}
+										value={scientificName}
+										onChange={(e) => setScientificName(e.target.value)}
+									/>
+								</FormControl>
+								<FormMessage fieldName="scientificName" />
+							</FormItem>
+						</div>
+
+						<FormItem>
+							<FormLabel>{t('shared.fields.family.label')}</FormLabel>
+							<FormControl>
+								<Input
+									placeholder={t('shared.fields.family.placeholder')}
+									disabled={isLoading}
+									value={family || ''}
+									onChange={(e) => setFamily(e.target.value || null)}
+								/>
+							</FormControl>
+							<FormMessage fieldName="family" />
+						</FormItem>
+
+						<FormItem>
+							<FormLabel>{t('shared.fields.description.label')}</FormLabel>
+							<FormControl>
+								<Textarea
+									placeholder={t('shared.fields.description.placeholder')}
+									disabled={isLoading}
+									value={description || ''}
+									onChange={(e) => setDescription(e.target.value || null)}
+									rows={3}
+								/>
+							</FormControl>
+							<FormMessage fieldName="description" />
+						</FormItem>
+
+						{/* Classification */}
+						<div className="grid grid-cols-2 gap-4">
+							<FormItem>
+								<FormLabel>{t('shared.fields.category.label')}</FormLabel>
+								<Select
+									onValueChange={setCategory}
+									value={category}
+									disabled={isLoading}
+								>
+									<FormControl>
+										<SelectTrigger>
+											<SelectValue
+												placeholder={t('shared.fields.category.placeholder')}
+											/>
+										</SelectTrigger>
+									</FormControl>
+									<SelectContent>
+										{Object.values(PlantSpeciesCategory).map((cat) => (
+											<SelectItem key={cat} value={cat}>
+												{PLANT_SPECIES_CATEGORIES[cat].icon}{' '}
+												{PLANT_SPECIES_CATEGORIES[cat].label}
+											</SelectItem>
+										))}
+									</SelectContent>
+								</Select>
+								<FormMessage fieldName="category" />
+							</FormItem>
+
+							<FormItem>
+								<FormLabel>{t('shared.fields.difficulty.label')}</FormLabel>
+								<Select
+									onValueChange={setDifficulty}
+									value={difficulty}
+									disabled={isLoading}
+								>
+									<FormControl>
+										<SelectTrigger>
+											<SelectValue
+												placeholder={t('shared.fields.difficulty.placeholder')}
+											/>
+										</SelectTrigger>
+									</FormControl>
+									<SelectContent>
+										{Object.values(PlantSpeciesDifficulty).map((diff) => (
+											<SelectItem key={diff} value={diff}>
+												{PLANT_SPECIES_DIFFICULTY[diff].icon}{' '}
+												{PLANT_SPECIES_DIFFICULTY[diff].label}
+											</SelectItem>
+										))}
+									</SelectContent>
+								</Select>
+								<FormMessage fieldName="difficulty" />
+							</FormItem>
+						</div>
+
+						<FormItem>
+							<FormLabel>{t('shared.fields.growthRate.label')}</FormLabel>
+							<Select
+								onValueChange={setGrowthRate}
+								value={growthRate}
+								disabled={isLoading}
+							>
+								<FormControl>
+									<SelectTrigger>
+										<SelectValue
+											placeholder={t('shared.fields.growthRate.placeholder')}
+										/>
+									</SelectTrigger>
+								</FormControl>
+								<SelectContent>
+									{Object.values(PlantSpeciesGrowthRate).map((rate) => (
+										<SelectItem key={rate} value={rate}>
+											{rate}
+										</SelectItem>
+									))}
+								</SelectContent>
+							</Select>
+							<FormMessage fieldName="growthRate" />
+						</FormItem>
+
+						{/* Care Requirements */}
+						<div className="grid grid-cols-2 gap-4">
+							<FormItem>
+								<FormLabel>
+									{t('shared.fields.lightRequirements.label')}
+								</FormLabel>
+								<Select
+									onValueChange={setLightRequirements}
+									value={lightRequirements}
+									disabled={isLoading}
+								>
+									<FormControl>
+										<SelectTrigger>
+											<SelectValue
+												placeholder={t(
+													'shared.fields.lightRequirements.placeholder',
+												)}
+											/>
+										</SelectTrigger>
+									</FormControl>
+									<SelectContent>
+										{Object.values(PlantSpeciesLightRequirements).map((req) => (
+											<SelectItem key={req} value={req}>
+												{PLANT_SPECIES_LIGHT_REQUIREMENTS[req].icon}{' '}
+												{PLANT_SPECIES_LIGHT_REQUIREMENTS[req].label}
+											</SelectItem>
+										))}
+									</SelectContent>
+								</Select>
+								<FormMessage fieldName="lightRequirements" />
+							</FormItem>
+
+							<FormItem>
+								<FormLabel>
+									{t('shared.fields.waterRequirements.label')}
+								</FormLabel>
+								<Select
+									onValueChange={setWaterRequirements}
+									value={waterRequirements}
+									disabled={isLoading}
+								>
+									<FormControl>
+										<SelectTrigger>
+											<SelectValue
+												placeholder={t(
+													'shared.fields.waterRequirements.placeholder',
+												)}
+											/>
+										</SelectTrigger>
+									</FormControl>
+									<SelectContent>
+										{Object.values(PlantSpeciesWaterRequirements).map((req) => (
+											<SelectItem key={req} value={req}>
+												{PLANT_SPECIES_WATER_REQUIREMENTS[req].icon}{' '}
+												{PLANT_SPECIES_WATER_REQUIREMENTS[req].label}
+											</SelectItem>
+										))}
+									</SelectContent>
+								</Select>
+								<FormMessage fieldName="waterRequirements" />
+							</FormItem>
+						</div>
+
+						<div className="grid grid-cols-2 gap-4">
+							<FormItem>
+								<FormLabel>
+									{t('shared.fields.humidityRequirements.label')}
+								</FormLabel>
+								<Select
+									onValueChange={(v) =>
+										setHumidityRequirements(v === 'none' ? null : v)
+									}
+									value={humidityRequirements || 'none'}
+									disabled={isLoading}
+								>
+									<FormControl>
+										<SelectTrigger>
+											<SelectValue
+												placeholder={t(
+													'shared.fields.humidityRequirements.placeholder',
+												)}
+											/>
+										</SelectTrigger>
+									</FormControl>
+									<SelectContent>
+										<SelectItem value="none">{t('common.none')}</SelectItem>
+										{Object.values(PlantSpeciesHumidityRequirements).map(
+											(req) => (
+												<SelectItem key={req} value={req}>
+													{req}
+												</SelectItem>
+											),
+										)}
+									</SelectContent>
+								</Select>
+								<FormMessage fieldName="humidityRequirements" />
+							</FormItem>
+
+							<FormItem>
+								<FormLabel>{t('shared.fields.soilType.label')}</FormLabel>
+								<Select
+									onValueChange={(v) => setSoilType(v === 'none' ? null : v)}
+									value={soilType || 'none'}
+									disabled={isLoading}
+								>
+									<FormControl>
+										<SelectTrigger>
+											<SelectValue
+												placeholder={t('shared.fields.soilType.placeholder')}
+											/>
+										</SelectTrigger>
+									</FormControl>
+									<SelectContent>
+										<SelectItem value="none">{t('common.none')}</SelectItem>
+										{Object.values(PlantSpeciesSoilType).map((type) => (
+											<SelectItem key={type} value={type}>
+												{PLANT_SPECIES_SOIL_TYPE[type].icon}{' '}
+												{PLANT_SPECIES_SOIL_TYPE[type].label}
+											</SelectItem>
+										))}
+									</SelectContent>
+								</Select>
+								<FormMessage fieldName="soilType" />
+							</FormItem>
+						</div>
+
+						{/* Temperature Range */}
+						<div className="grid grid-cols-2 gap-4">
+							<FormItem>
+								<FormLabel>
+									{t('shared.fields.temperatureRange.min.label')}
+								</FormLabel>
+								<FormControl>
+									<Input
+										type="number"
+										placeholder={t(
+											'shared.fields.temperatureRange.min.placeholder',
+										)}
+										disabled={isLoading}
+										value={temperatureMin}
+										onChange={(e) => setTemperatureMin(e.target.value)}
+									/>
+								</FormControl>
+								<FormMessage fieldName="temperatureRange" />
+							</FormItem>
+
+							<FormItem>
+								<FormLabel>
+									{t('shared.fields.temperatureRange.max.label')}
+								</FormLabel>
+								<FormControl>
+									<Input
+										type="number"
+										placeholder={t(
+											'shared.fields.temperatureRange.max.placeholder',
+										)}
+										disabled={isLoading}
+										value={temperatureMax}
+										onChange={(e) => setTemperatureMax(e.target.value)}
+									/>
+								</FormControl>
+							</FormItem>
+						</div>
+
+						{/* pH Range */}
+						<div className="grid grid-cols-2 gap-4">
+							<FormItem>
+								<FormLabel>{t('shared.fields.phRange.min.label')}</FormLabel>
+								<FormControl>
+									<Input
+										type="number"
+										step="0.1"
+										placeholder={t('shared.fields.phRange.min.placeholder')}
+										disabled={isLoading}
+										value={phMin}
+										onChange={(e) => setPhMin(e.target.value)}
+									/>
+								</FormControl>
+								<FormMessage fieldName="phRange" />
+							</FormItem>
+
+							<FormItem>
+								<FormLabel>{t('shared.fields.phRange.max.label')}</FormLabel>
+								<FormControl>
+									<Input
+										type="number"
+										step="0.1"
+										placeholder={t('shared.fields.phRange.max.placeholder')}
+										disabled={isLoading}
+										value={phMax}
+										onChange={(e) => setPhMax(e.target.value)}
+									/>
+								</FormControl>
+							</FormItem>
+						</div>
+
+						{/* Mature Size */}
+						<div className="grid grid-cols-2 gap-4">
+							<FormItem>
+								<FormLabel>
+									{t('shared.fields.matureSize.height.label')}
+								</FormLabel>
+								<FormControl>
+									<Input
+										type="number"
+										placeholder={t(
+											'shared.fields.matureSize.height.placeholder',
+										)}
+										disabled={isLoading}
+										value={matureSizeHeight}
+										onChange={(e) => setMatureSizeHeight(e.target.value)}
+									/>
+								</FormControl>
+								<FormMessage fieldName="matureSize" />
+							</FormItem>
+
+							<FormItem>
+								<FormLabel>
+									{t('shared.fields.matureSize.width.label')}
+								</FormLabel>
+								<FormControl>
+									<Input
+										type="number"
+										placeholder={t('shared.fields.matureSize.width.placeholder')}
+										disabled={isLoading}
+										value={matureSizeWidth}
+										onChange={(e) => setMatureSizeWidth(e.target.value)}
+									/>
+								</FormControl>
+							</FormItem>
+						</div>
+
+						{/* Growth Time */}
+						<FormItem>
+							<FormLabel>{t('shared.fields.growthTime.label')}</FormLabel>
+							<FormControl>
+								<Input
+									type="number"
+									placeholder={t('shared.fields.growthTime.placeholder')}
+									disabled={isLoading}
+									value={growthTime}
+									onChange={(e) => setGrowthTime(e.target.value)}
+								/>
+							</FormControl>
+							<FormMessage fieldName="growthTime" />
+						</FormItem>
+
+						{/* Tags */}
+						<FormItem>
+							<FormLabel>{t('shared.fields.tags.label')}</FormLabel>
+							<div className="flex gap-2">
+								<FormControl>
+									<Input
+										placeholder={t('shared.fields.tags.placeholder')}
+										disabled={isLoading}
+										value={tagInput}
+										onChange={(e) => setTagInput(e.target.value)}
+										onKeyDown={(e) => {
+											if (e.key === 'Enter') {
+												e.preventDefault();
+												addTag();
+											}
+										}}
+									/>
+								</FormControl>
+								<Button
+									type="button"
+									variant="outline"
+									onClick={addTag}
+									disabled={isLoading || !tagInput.trim()}
+								>
+									{t('common.add')}
+								</Button>
+							</div>
+							{tags.length > 0 && (
+								<div className="flex flex-wrap gap-2 mt-2">
+									{tags.map((tag) => (
+										<Badge key={tag} variant="secondary" className="gap-1">
+											{tag}
+											<button
+												type="button"
+												onClick={() => removeTag(tag)}
+												className="ml-1 hover:text-destructive"
+											>
+												<XIcon className="h-3 w-3" />
+											</button>
+										</Badge>
+									))}
+								</div>
+							)}
+							<FormMessage fieldName="tags" />
+						</FormItem>
+
+						{error && (
+							<div className="text-sm text-destructive">{error.message}</div>
+						)}
+
+						<DialogFooter>
+							<Button
+								type="button"
+								variant="outline"
+								onClick={() => handleOpenChange(false)}
+								disabled={isLoading}
+							>
+								{t('common.cancel')}
+							</Button>
+							<Button type="submit" disabled={isLoading}>
+								{isLoading
+									? t('features.plantSpecies.list.actions.create.loading')
+									: t('features.plantSpecies.list.actions.create.submit')}
+							</Button>
+						</DialogFooter>
+					</form>
+				</Form>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/apps/web/features/plant-species/components/forms/PlantSpeciesCreateForm/usePlantSpeciesCreateForm.ts
+++ b/apps/web/features/plant-species/components/forms/PlantSpeciesCreateForm/usePlantSpeciesCreateForm.ts
@@ -1,0 +1,257 @@
+'use client';
+
+import {
+	createPlantSpeciesCreateSchema,
+	type PlantSpeciesCreateFormValues,
+} from '@/features/plant-species/schemas/plant-species-create.schema';
+import { useMemo, useState } from 'react';
+
+interface UsePlantSpeciesCreateFormProps {
+	onSubmit: (values: PlantSpeciesCreateFormValues) => Promise<void>;
+	onOpenChange: (open: boolean) => void;
+	error: Error | null;
+	translations: (key: string) => string;
+}
+
+interface UsePlantSpeciesCreateFormReturn {
+	// Form state
+	commonName: string;
+	scientificName: string;
+	family: string | null;
+	description: string | null;
+	category: string;
+	difficulty: string;
+	growthRate: string;
+	lightRequirements: string;
+	waterRequirements: string;
+	humidityRequirements: string | null;
+	soilType: string | null;
+	temperatureMin: string;
+	temperatureMax: string;
+	phMin: string;
+	phMax: string;
+	matureSizeHeight: string;
+	matureSizeWidth: string;
+	growthTime: string;
+	tags: string[];
+	tagInput: string;
+	formErrors: Record<string, { message?: string }>;
+
+	// State setters
+	setCommonName: (value: string) => void;
+	setScientificName: (value: string) => void;
+	setFamily: (value: string | null) => void;
+	setDescription: (value: string | null) => void;
+	setCategory: (value: string) => void;
+	setDifficulty: (value: string) => void;
+	setGrowthRate: (value: string) => void;
+	setLightRequirements: (value: string) => void;
+	setWaterRequirements: (value: string) => void;
+	setHumidityRequirements: (value: string | null) => void;
+	setSoilType: (value: string | null) => void;
+	setTemperatureMin: (value: string) => void;
+	setTemperatureMax: (value: string) => void;
+	setPhMin: (value: string) => void;
+	setPhMax: (value: string) => void;
+	setMatureSizeHeight: (value: string) => void;
+	setMatureSizeWidth: (value: string) => void;
+	setGrowthTime: (value: string) => void;
+	setTagInput: (value: string) => void;
+	addTag: () => void;
+	removeTag: (tag: string) => void;
+
+	// Event handlers
+	handleSubmit: (e: React.FormEvent<HTMLFormElement>) => Promise<void>;
+	handleOpenChange: (newOpen: boolean) => void;
+}
+
+export function usePlantSpeciesCreateForm({
+	onSubmit,
+	onOpenChange,
+	error,
+	translations,
+}: UsePlantSpeciesCreateFormProps): UsePlantSpeciesCreateFormReturn {
+	const createSchema = useMemo(
+		() => createPlantSpeciesCreateSchema(translations),
+		[translations],
+	);
+
+	const [commonName, setCommonName] = useState('');
+	const [scientificName, setScientificName] = useState('');
+	const [family, setFamily] = useState<string | null>(null);
+	const [description, setDescription] = useState<string | null>(null);
+	const [category, setCategory] = useState('');
+	const [difficulty, setDifficulty] = useState('');
+	const [growthRate, setGrowthRate] = useState('');
+	const [lightRequirements, setLightRequirements] = useState('');
+	const [waterRequirements, setWaterRequirements] = useState('');
+	const [humidityRequirements, setHumidityRequirements] = useState<string | null>(null);
+	const [soilType, setSoilType] = useState<string | null>(null);
+	const [temperatureMin, setTemperatureMin] = useState('');
+	const [temperatureMax, setTemperatureMax] = useState('');
+	const [phMin, setPhMin] = useState('');
+	const [phMax, setPhMax] = useState('');
+	const [matureSizeHeight, setMatureSizeHeight] = useState('');
+	const [matureSizeWidth, setMatureSizeWidth] = useState('');
+	const [growthTime, setGrowthTime] = useState('');
+	const [tags, setTags] = useState<string[]>([]);
+	const [tagInput, setTagInput] = useState('');
+	const [formErrors, setFormErrors] = useState<Record<string, { message?: string }>>({});
+
+	const resetForm = () => {
+		setCommonName('');
+		setScientificName('');
+		setFamily(null);
+		setDescription(null);
+		setCategory('');
+		setDifficulty('');
+		setGrowthRate('');
+		setLightRequirements('');
+		setWaterRequirements('');
+		setHumidityRequirements(null);
+		setSoilType(null);
+		setTemperatureMin('');
+		setTemperatureMax('');
+		setPhMin('');
+		setPhMax('');
+		setMatureSizeHeight('');
+		setMatureSizeWidth('');
+		setGrowthTime('');
+		setTags([]);
+		setTagInput('');
+		setFormErrors({});
+	};
+
+	const addTag = () => {
+		const trimmed = tagInput.trim();
+		if (trimmed && !tags.includes(trimmed)) {
+			setTags([...tags, trimmed]);
+			setTagInput('');
+		}
+	};
+
+	const removeTag = (tag: string) => {
+		setTags(tags.filter((t) => t !== tag));
+	};
+
+	const buildFormData = () => {
+		const data: Record<string, unknown> = {
+			commonName,
+			scientificName,
+			category,
+			difficulty,
+			growthRate,
+			lightRequirements,
+			waterRequirements,
+		};
+
+		if (family) data.family = family;
+		if (description) data.description = description;
+		if (humidityRequirements) data.humidityRequirements = humidityRequirements;
+		if (soilType) data.soilType = soilType;
+		if (tags.length > 0) data.tags = tags;
+		if (growthTime) data.growthTime = parseFloat(growthTime);
+
+		if (temperatureMin && temperatureMax) {
+			data.temperatureRange = {
+				min: parseFloat(temperatureMin),
+				max: parseFloat(temperatureMax),
+			};
+		}
+
+		if (phMin && phMax) {
+			data.phRange = {
+				min: parseFloat(phMin),
+				max: parseFloat(phMax),
+			};
+		}
+
+		if (matureSizeHeight && matureSizeWidth) {
+			data.matureSize = {
+				height: parseFloat(matureSizeHeight),
+				width: parseFloat(matureSizeWidth),
+			};
+		}
+
+		return data;
+	};
+
+	const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+		e.preventDefault();
+
+		const data = buildFormData();
+		const result = createSchema.safeParse(data);
+
+		if (!result.success) {
+			const errors: Record<string, { message?: string }> = {};
+			result.error.issues.forEach((err) => {
+				if (err.path[0]) {
+					errors[err.path[0] as string] = { message: err.message };
+				}
+			});
+			setFormErrors(errors);
+			return;
+		}
+
+		setFormErrors({});
+		await onSubmit(result.data);
+		if (!error) {
+			resetForm();
+			onOpenChange(false);
+		}
+	};
+
+	const handleOpenChange = (newOpen: boolean) => {
+		if (!newOpen) {
+			resetForm();
+		}
+		onOpenChange(newOpen);
+	};
+
+	return {
+		commonName,
+		scientificName,
+		family,
+		description,
+		category,
+		difficulty,
+		growthRate,
+		lightRequirements,
+		waterRequirements,
+		humidityRequirements,
+		soilType,
+		temperatureMin,
+		temperatureMax,
+		phMin,
+		phMax,
+		matureSizeHeight,
+		matureSizeWidth,
+		growthTime,
+		tags,
+		tagInput,
+		formErrors,
+		setCommonName,
+		setScientificName,
+		setFamily,
+		setDescription,
+		setCategory,
+		setDifficulty,
+		setGrowthRate,
+		setLightRequirements,
+		setWaterRequirements,
+		setHumidityRequirements,
+		setSoilType,
+		setTemperatureMin,
+		setTemperatureMax,
+		setPhMin,
+		setPhMax,
+		setMatureSizeHeight,
+		setMatureSizeWidth,
+		setGrowthTime,
+		setTagInput,
+		addTag,
+		removeTag,
+		handleSubmit,
+		handleOpenChange,
+	};
+}

--- a/apps/web/features/plant-species/components/forms/PlantSpeciesUpdateForm/PlantSpeciesUpdateForm.tsx
+++ b/apps/web/features/plant-species/components/forms/PlantSpeciesUpdateForm/PlantSpeciesUpdateForm.tsx
@@ -1,0 +1,595 @@
+'use client';
+
+import type { PlantSpeciesResponse } from '@/features/plant-species/api/types/plant-species-response.types';
+import {
+	PlantSpeciesCategory,
+	PlantSpeciesDifficulty,
+	PlantSpeciesGrowthRate,
+	PlantSpeciesHumidityRequirements,
+	PlantSpeciesLightRequirements,
+	PlantSpeciesSoilType,
+	PlantSpeciesWaterRequirements,
+} from '@/features/plant-species/api/types/plant-species.types';
+import { PLANT_SPECIES_CATEGORIES } from '@/features/plant-species/constants/plant-species-categories';
+import { PLANT_SPECIES_DIFFICULTY } from '@/features/plant-species/constants/plant-species-difficulty';
+import {
+	PLANT_SPECIES_LIGHT_REQUIREMENTS,
+	PLANT_SPECIES_SOIL_TYPE,
+	PLANT_SPECIES_WATER_REQUIREMENTS,
+} from '@/features/plant-species/constants/plant-species-requirements';
+import type { PlantSpeciesUpdateFormValues } from '@/features/plant-species/schemas/plant-species-update.schema';
+import { Badge } from '@/shared/components/ui/badge';
+import { Button } from '@/shared/components/ui/button';
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from '@/shared/components/ui/dialog';
+import {
+	Form,
+	FormControl,
+	FormItem,
+	FormLabel,
+	FormMessage,
+} from '@/shared/components/ui/form';
+import { Input } from '@/shared/components/ui/input';
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from '@/shared/components/ui/select';
+import { Textarea } from '@/shared/components/ui/textarea';
+import { XIcon } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+import { usePlantSpeciesUpdateForm } from './usePlantSpeciesUpdateForm';
+
+interface PlantSpeciesUpdateFormProps {
+	plantSpecies: PlantSpeciesResponse | null;
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	onSubmit: (values: PlantSpeciesUpdateFormValues) => Promise<void>;
+	isLoading: boolean;
+	error: Error | null;
+}
+
+export function PlantSpeciesUpdateForm({
+	plantSpecies,
+	open,
+	onOpenChange,
+	onSubmit,
+	isLoading,
+	error,
+}: PlantSpeciesUpdateFormProps) {
+	const t = useTranslations();
+
+	const {
+		commonName,
+		scientificName,
+		family,
+		description,
+		category,
+		difficulty,
+		growthRate,
+		lightRequirements,
+		waterRequirements,
+		humidityRequirements,
+		soilType,
+		temperatureMin,
+		temperatureMax,
+		phMin,
+		phMax,
+		matureSizeHeight,
+		matureSizeWidth,
+		growthTime,
+		tags,
+		tagInput,
+		formErrors,
+		setCommonName,
+		setScientificName,
+		setFamily,
+		setDescription,
+		setCategory,
+		setDifficulty,
+		setGrowthRate,
+		setLightRequirements,
+		setWaterRequirements,
+		setHumidityRequirements,
+		setSoilType,
+		setTemperatureMin,
+		setTemperatureMax,
+		setPhMin,
+		setPhMax,
+		setMatureSizeHeight,
+		setMatureSizeWidth,
+		setGrowthTime,
+		setTagInput,
+		addTag,
+		removeTag,
+		handleSubmit,
+		handleOpenChange,
+	} = usePlantSpeciesUpdateForm({
+		plantSpecies,
+		onSubmit,
+		onOpenChange,
+		error,
+		translations: (key: string) => t(key),
+	});
+
+	const isVerified = plantSpecies?.isVerified ?? false;
+
+	if (!plantSpecies) {
+		return null;
+	}
+
+	return (
+		<Dialog open={open} onOpenChange={handleOpenChange}>
+			<DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
+				<DialogHeader>
+					<DialogTitle>
+						{t('features.plantSpecies.list.actions.update.title')}
+					</DialogTitle>
+					<DialogDescription>
+						{t('features.plantSpecies.list.actions.update.description')}
+					</DialogDescription>
+				</DialogHeader>
+				<Form errors={formErrors}>
+					<form onSubmit={handleSubmit} className="space-y-4">
+						{/* Basic Info */}
+						<div className="grid grid-cols-2 gap-4">
+							<FormItem>
+								<FormLabel>{t('shared.fields.commonName.label')}</FormLabel>
+								<FormControl>
+									<Input
+										placeholder={t('shared.fields.commonName.placeholder')}
+										disabled={isLoading || isVerified}
+										value={commonName}
+										onChange={(e) => setCommonName(e.target.value)}
+									/>
+								</FormControl>
+								<FormMessage fieldName="commonName" />
+							</FormItem>
+
+							<FormItem>
+								<FormLabel>{t('shared.fields.scientificName.label')}</FormLabel>
+								<FormControl>
+									<Input
+										placeholder={t('shared.fields.scientificName.placeholder')}
+										disabled={isLoading || isVerified}
+										value={scientificName}
+										onChange={(e) => setScientificName(e.target.value)}
+									/>
+								</FormControl>
+								<FormMessage fieldName="scientificName" />
+							</FormItem>
+						</div>
+
+						<FormItem>
+							<FormLabel>{t('shared.fields.family.label')}</FormLabel>
+							<FormControl>
+								<Input
+									placeholder={t('shared.fields.family.placeholder')}
+									disabled={isLoading}
+									value={family || ''}
+									onChange={(e) => setFamily(e.target.value || null)}
+								/>
+							</FormControl>
+							<FormMessage fieldName="family" />
+						</FormItem>
+
+						<FormItem>
+							<FormLabel>{t('shared.fields.description.label')}</FormLabel>
+							<FormControl>
+								<Textarea
+									placeholder={t('shared.fields.description.placeholder')}
+									disabled={isLoading}
+									value={description || ''}
+									onChange={(e) => setDescription(e.target.value || null)}
+									rows={3}
+								/>
+							</FormControl>
+							<FormMessage fieldName="description" />
+						</FormItem>
+
+						{/* Classification */}
+						<div className="grid grid-cols-2 gap-4">
+							<FormItem>
+								<FormLabel>{t('shared.fields.category.label')}</FormLabel>
+								<Select
+									onValueChange={setCategory}
+									value={category}
+									disabled={isLoading}
+								>
+									<FormControl>
+										<SelectTrigger>
+											<SelectValue
+												placeholder={t('shared.fields.category.placeholder')}
+											/>
+										</SelectTrigger>
+									</FormControl>
+									<SelectContent>
+										{Object.values(PlantSpeciesCategory).map((cat) => (
+											<SelectItem key={cat} value={cat}>
+												{PLANT_SPECIES_CATEGORIES[cat].icon}{' '}
+												{PLANT_SPECIES_CATEGORIES[cat].label}
+											</SelectItem>
+										))}
+									</SelectContent>
+								</Select>
+								<FormMessage fieldName="category" />
+							</FormItem>
+
+							<FormItem>
+								<FormLabel>{t('shared.fields.difficulty.label')}</FormLabel>
+								<Select
+									onValueChange={setDifficulty}
+									value={difficulty}
+									disabled={isLoading}
+								>
+									<FormControl>
+										<SelectTrigger>
+											<SelectValue
+												placeholder={t('shared.fields.difficulty.placeholder')}
+											/>
+										</SelectTrigger>
+									</FormControl>
+									<SelectContent>
+										{Object.values(PlantSpeciesDifficulty).map((diff) => (
+											<SelectItem key={diff} value={diff}>
+												{PLANT_SPECIES_DIFFICULTY[diff].icon}{' '}
+												{PLANT_SPECIES_DIFFICULTY[diff].label}
+											</SelectItem>
+										))}
+									</SelectContent>
+								</Select>
+								<FormMessage fieldName="difficulty" />
+							</FormItem>
+						</div>
+
+						<FormItem>
+							<FormLabel>{t('shared.fields.growthRate.label')}</FormLabel>
+							<Select
+								onValueChange={setGrowthRate}
+								value={growthRate}
+								disabled={isLoading}
+							>
+								<FormControl>
+									<SelectTrigger>
+										<SelectValue
+											placeholder={t('shared.fields.growthRate.placeholder')}
+										/>
+									</SelectTrigger>
+								</FormControl>
+								<SelectContent>
+									{Object.values(PlantSpeciesGrowthRate).map((rate) => (
+										<SelectItem key={rate} value={rate}>
+											{rate}
+										</SelectItem>
+									))}
+								</SelectContent>
+							</Select>
+							<FormMessage fieldName="growthRate" />
+						</FormItem>
+
+						{/* Care Requirements */}
+						<div className="grid grid-cols-2 gap-4">
+							<FormItem>
+								<FormLabel>
+									{t('shared.fields.lightRequirements.label')}
+								</FormLabel>
+								<Select
+									onValueChange={setLightRequirements}
+									value={lightRequirements}
+									disabled={isLoading}
+								>
+									<FormControl>
+										<SelectTrigger>
+											<SelectValue
+												placeholder={t(
+													'shared.fields.lightRequirements.placeholder',
+												)}
+											/>
+										</SelectTrigger>
+									</FormControl>
+									<SelectContent>
+										{Object.values(PlantSpeciesLightRequirements).map((req) => (
+											<SelectItem key={req} value={req}>
+												{PLANT_SPECIES_LIGHT_REQUIREMENTS[req].icon}{' '}
+												{PLANT_SPECIES_LIGHT_REQUIREMENTS[req].label}
+											</SelectItem>
+										))}
+									</SelectContent>
+								</Select>
+								<FormMessage fieldName="lightRequirements" />
+							</FormItem>
+
+							<FormItem>
+								<FormLabel>
+									{t('shared.fields.waterRequirements.label')}
+								</FormLabel>
+								<Select
+									onValueChange={setWaterRequirements}
+									value={waterRequirements}
+									disabled={isLoading}
+								>
+									<FormControl>
+										<SelectTrigger>
+											<SelectValue
+												placeholder={t(
+													'shared.fields.waterRequirements.placeholder',
+												)}
+											/>
+										</SelectTrigger>
+									</FormControl>
+									<SelectContent>
+										{Object.values(PlantSpeciesWaterRequirements).map((req) => (
+											<SelectItem key={req} value={req}>
+												{PLANT_SPECIES_WATER_REQUIREMENTS[req].icon}{' '}
+												{PLANT_SPECIES_WATER_REQUIREMENTS[req].label}
+											</SelectItem>
+										))}
+									</SelectContent>
+								</Select>
+								<FormMessage fieldName="waterRequirements" />
+							</FormItem>
+						</div>
+
+						<div className="grid grid-cols-2 gap-4">
+							<FormItem>
+								<FormLabel>
+									{t('shared.fields.humidityRequirements.label')}
+								</FormLabel>
+								<Select
+									onValueChange={(v) =>
+										setHumidityRequirements(v === 'none' ? null : v)
+									}
+									value={humidityRequirements || 'none'}
+									disabled={isLoading}
+								>
+									<FormControl>
+										<SelectTrigger>
+											<SelectValue
+												placeholder={t(
+													'shared.fields.humidityRequirements.placeholder',
+												)}
+											/>
+										</SelectTrigger>
+									</FormControl>
+									<SelectContent>
+										<SelectItem value="none">{t('common.none')}</SelectItem>
+										{Object.values(PlantSpeciesHumidityRequirements).map(
+											(req) => (
+												<SelectItem key={req} value={req}>
+													{req}
+												</SelectItem>
+											),
+										)}
+									</SelectContent>
+								</Select>
+								<FormMessage fieldName="humidityRequirements" />
+							</FormItem>
+
+							<FormItem>
+								<FormLabel>{t('shared.fields.soilType.label')}</FormLabel>
+								<Select
+									onValueChange={(v) => setSoilType(v === 'none' ? null : v)}
+									value={soilType || 'none'}
+									disabled={isLoading}
+								>
+									<FormControl>
+										<SelectTrigger>
+											<SelectValue
+												placeholder={t('shared.fields.soilType.placeholder')}
+											/>
+										</SelectTrigger>
+									</FormControl>
+									<SelectContent>
+										<SelectItem value="none">{t('common.none')}</SelectItem>
+										{Object.values(PlantSpeciesSoilType).map((type) => (
+											<SelectItem key={type} value={type}>
+												{PLANT_SPECIES_SOIL_TYPE[type].icon}{' '}
+												{PLANT_SPECIES_SOIL_TYPE[type].label}
+											</SelectItem>
+										))}
+									</SelectContent>
+								</Select>
+								<FormMessage fieldName="soilType" />
+							</FormItem>
+						</div>
+
+						{/* Temperature Range */}
+						<div className="grid grid-cols-2 gap-4">
+							<FormItem>
+								<FormLabel>
+									{t('shared.fields.temperatureRange.min.label')}
+								</FormLabel>
+								<FormControl>
+									<Input
+										type="number"
+										placeholder={t(
+											'shared.fields.temperatureRange.min.placeholder',
+										)}
+										disabled={isLoading}
+										value={temperatureMin}
+										onChange={(e) => setTemperatureMin(e.target.value)}
+									/>
+								</FormControl>
+								<FormMessage fieldName="temperatureRange" />
+							</FormItem>
+
+							<FormItem>
+								<FormLabel>
+									{t('shared.fields.temperatureRange.max.label')}
+								</FormLabel>
+								<FormControl>
+									<Input
+										type="number"
+										placeholder={t(
+											'shared.fields.temperatureRange.max.placeholder',
+										)}
+										disabled={isLoading}
+										value={temperatureMax}
+										onChange={(e) => setTemperatureMax(e.target.value)}
+									/>
+								</FormControl>
+							</FormItem>
+						</div>
+
+						{/* pH Range */}
+						<div className="grid grid-cols-2 gap-4">
+							<FormItem>
+								<FormLabel>{t('shared.fields.phRange.min.label')}</FormLabel>
+								<FormControl>
+									<Input
+										type="number"
+										step="0.1"
+										placeholder={t('shared.fields.phRange.min.placeholder')}
+										disabled={isLoading}
+										value={phMin}
+										onChange={(e) => setPhMin(e.target.value)}
+									/>
+								</FormControl>
+								<FormMessage fieldName="phRange" />
+							</FormItem>
+
+							<FormItem>
+								<FormLabel>{t('shared.fields.phRange.max.label')}</FormLabel>
+								<FormControl>
+									<Input
+										type="number"
+										step="0.1"
+										placeholder={t('shared.fields.phRange.max.placeholder')}
+										disabled={isLoading}
+										value={phMax}
+										onChange={(e) => setPhMax(e.target.value)}
+									/>
+								</FormControl>
+							</FormItem>
+						</div>
+
+						{/* Mature Size */}
+						<div className="grid grid-cols-2 gap-4">
+							<FormItem>
+								<FormLabel>
+									{t('shared.fields.matureSize.height.label')}
+								</FormLabel>
+								<FormControl>
+									<Input
+										type="number"
+										placeholder={t(
+											'shared.fields.matureSize.height.placeholder',
+										)}
+										disabled={isLoading}
+										value={matureSizeHeight}
+										onChange={(e) => setMatureSizeHeight(e.target.value)}
+									/>
+								</FormControl>
+								<FormMessage fieldName="matureSize" />
+							</FormItem>
+
+							<FormItem>
+								<FormLabel>
+									{t('shared.fields.matureSize.width.label')}
+								</FormLabel>
+								<FormControl>
+									<Input
+										type="number"
+										placeholder={t('shared.fields.matureSize.width.placeholder')}
+										disabled={isLoading}
+										value={matureSizeWidth}
+										onChange={(e) => setMatureSizeWidth(e.target.value)}
+									/>
+								</FormControl>
+							</FormItem>
+						</div>
+
+						{/* Growth Time */}
+						<FormItem>
+							<FormLabel>{t('shared.fields.growthTime.label')}</FormLabel>
+							<FormControl>
+								<Input
+									type="number"
+									placeholder={t('shared.fields.growthTime.placeholder')}
+									disabled={isLoading}
+									value={growthTime}
+									onChange={(e) => setGrowthTime(e.target.value)}
+								/>
+							</FormControl>
+							<FormMessage fieldName="growthTime" />
+						</FormItem>
+
+						{/* Tags */}
+						<FormItem>
+							<FormLabel>{t('shared.fields.tags.label')}</FormLabel>
+							<div className="flex gap-2">
+								<FormControl>
+									<Input
+										placeholder={t('shared.fields.tags.placeholder')}
+										disabled={isLoading}
+										value={tagInput}
+										onChange={(e) => setTagInput(e.target.value)}
+										onKeyDown={(e) => {
+											if (e.key === 'Enter') {
+												e.preventDefault();
+												addTag();
+											}
+										}}
+									/>
+								</FormControl>
+								<Button
+									type="button"
+									variant="outline"
+									onClick={addTag}
+									disabled={isLoading || !tagInput.trim()}
+								>
+									{t('common.add')}
+								</Button>
+							</div>
+							{tags.length > 0 && (
+								<div className="flex flex-wrap gap-2 mt-2">
+									{tags.map((tag) => (
+										<Badge key={tag} variant="secondary" className="gap-1">
+											{tag}
+											<button
+												type="button"
+												onClick={() => removeTag(tag)}
+												className="ml-1 hover:text-destructive"
+											>
+												<XIcon className="h-3 w-3" />
+											</button>
+										</Badge>
+									))}
+								</div>
+							)}
+							<FormMessage fieldName="tags" />
+						</FormItem>
+
+						{error && (
+							<div className="text-sm text-destructive">{error.message}</div>
+						)}
+
+						<DialogFooter>
+							<Button
+								type="button"
+								variant="outline"
+								onClick={() => handleOpenChange(false)}
+								disabled={isLoading}
+							>
+								{t('common.cancel')}
+							</Button>
+							<Button type="submit" disabled={isLoading}>
+								{isLoading
+									? t('features.plantSpecies.list.actions.update.loading')
+									: t('features.plantSpecies.list.actions.update.submit')}
+							</Button>
+						</DialogFooter>
+					</form>
+				</Form>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/apps/web/features/plant-species/components/forms/PlantSpeciesUpdateForm/usePlantSpeciesUpdateForm.ts
+++ b/apps/web/features/plant-species/components/forms/PlantSpeciesUpdateForm/usePlantSpeciesUpdateForm.ts
@@ -1,0 +1,287 @@
+'use client';
+
+import type { PlantSpeciesResponse } from '@/features/plant-species/api/types/plant-species-response.types';
+import {
+	createPlantSpeciesUpdateSchema,
+	type PlantSpeciesUpdateFormValues,
+} from '@/features/plant-species/schemas/plant-species-update.schema';
+import { useEffect, useMemo, useState } from 'react';
+
+interface UsePlantSpeciesUpdateFormProps {
+	plantSpecies: PlantSpeciesResponse | null;
+	onSubmit: (values: PlantSpeciesUpdateFormValues) => Promise<void>;
+	onOpenChange: (open: boolean) => void;
+	error: Error | null;
+	translations: (key: string) => string;
+}
+
+interface UsePlantSpeciesUpdateFormReturn {
+	// Form state
+	commonName: string;
+	scientificName: string;
+	family: string | null;
+	description: string | null;
+	category: string;
+	difficulty: string;
+	growthRate: string;
+	lightRequirements: string;
+	waterRequirements: string;
+	humidityRequirements: string | null;
+	soilType: string | null;
+	temperatureMin: string;
+	temperatureMax: string;
+	phMin: string;
+	phMax: string;
+	matureSizeHeight: string;
+	matureSizeWidth: string;
+	growthTime: string;
+	tags: string[];
+	tagInput: string;
+	formErrors: Record<string, { message?: string }>;
+
+	// State setters
+	setCommonName: (value: string) => void;
+	setScientificName: (value: string) => void;
+	setFamily: (value: string | null) => void;
+	setDescription: (value: string | null) => void;
+	setCategory: (value: string) => void;
+	setDifficulty: (value: string) => void;
+	setGrowthRate: (value: string) => void;
+	setLightRequirements: (value: string) => void;
+	setWaterRequirements: (value: string) => void;
+	setHumidityRequirements: (value: string | null) => void;
+	setSoilType: (value: string | null) => void;
+	setTemperatureMin: (value: string) => void;
+	setTemperatureMax: (value: string) => void;
+	setPhMin: (value: string) => void;
+	setPhMax: (value: string) => void;
+	setMatureSizeHeight: (value: string) => void;
+	setMatureSizeWidth: (value: string) => void;
+	setGrowthTime: (value: string) => void;
+	setTagInput: (value: string) => void;
+	addTag: () => void;
+	removeTag: (tag: string) => void;
+
+	// Event handlers
+	handleSubmit: (e: React.FormEvent<HTMLFormElement>) => Promise<void>;
+	handleOpenChange: (newOpen: boolean) => void;
+}
+
+export function usePlantSpeciesUpdateForm({
+	plantSpecies,
+	onSubmit,
+	onOpenChange,
+	error,
+	translations,
+}: UsePlantSpeciesUpdateFormProps): UsePlantSpeciesUpdateFormReturn {
+	const updateSchema = useMemo(
+		() => createPlantSpeciesUpdateSchema(translations),
+		[translations],
+	);
+
+	const [commonName, setCommonName] = useState('');
+	const [scientificName, setScientificName] = useState('');
+	const [family, setFamily] = useState<string | null>(null);
+	const [description, setDescription] = useState<string | null>(null);
+	const [category, setCategory] = useState('');
+	const [difficulty, setDifficulty] = useState('');
+	const [growthRate, setGrowthRate] = useState('');
+	const [lightRequirements, setLightRequirements] = useState('');
+	const [waterRequirements, setWaterRequirements] = useState('');
+	const [humidityRequirements, setHumidityRequirements] = useState<string | null>(null);
+	const [soilType, setSoilType] = useState<string | null>(null);
+	const [temperatureMin, setTemperatureMin] = useState('');
+	const [temperatureMax, setTemperatureMax] = useState('');
+	const [phMin, setPhMin] = useState('');
+	const [phMax, setPhMax] = useState('');
+	const [matureSizeHeight, setMatureSizeHeight] = useState('');
+	const [matureSizeWidth, setMatureSizeWidth] = useState('');
+	const [growthTime, setGrowthTime] = useState('');
+	const [tags, setTags] = useState<string[]>([]);
+	const [tagInput, setTagInput] = useState('');
+	const [formErrors, setFormErrors] = useState<Record<string, { message?: string }>>({});
+
+	useEffect(() => {
+		if (plantSpecies) {
+			setCommonName(plantSpecies.commonName);
+			setScientificName(plantSpecies.scientificName);
+			setFamily(plantSpecies.family || null);
+			setDescription(plantSpecies.description || null);
+			setCategory(plantSpecies.category);
+			setDifficulty(plantSpecies.difficulty);
+			setGrowthRate(plantSpecies.growthRate);
+			setLightRequirements(plantSpecies.lightRequirements);
+			setWaterRequirements(plantSpecies.waterRequirements);
+			setHumidityRequirements(plantSpecies.humidityRequirements || null);
+			setSoilType(plantSpecies.soilType || null);
+			setTemperatureMin(plantSpecies.temperatureRange?.min?.toString() ?? '');
+			setTemperatureMax(plantSpecies.temperatureRange?.max?.toString() ?? '');
+			setPhMin(plantSpecies.phRange?.min?.toString() ?? '');
+			setPhMax(plantSpecies.phRange?.max?.toString() ?? '');
+			setMatureSizeHeight(plantSpecies.matureSize?.height?.toString() ?? '');
+			setMatureSizeWidth(plantSpecies.matureSize?.width?.toString() ?? '');
+			setGrowthTime(plantSpecies.growthTime?.toString() ?? '');
+			setTags(plantSpecies.tags ?? []);
+			setFormErrors({});
+		}
+	}, [plantSpecies]);
+
+	const syncFromPlantSpecies = () => {
+		if (plantSpecies) {
+			setCommonName(plantSpecies.commonName);
+			setScientificName(plantSpecies.scientificName);
+			setFamily(plantSpecies.family || null);
+			setDescription(plantSpecies.description || null);
+			setCategory(plantSpecies.category);
+			setDifficulty(plantSpecies.difficulty);
+			setGrowthRate(plantSpecies.growthRate);
+			setLightRequirements(plantSpecies.lightRequirements);
+			setWaterRequirements(plantSpecies.waterRequirements);
+			setHumidityRequirements(plantSpecies.humidityRequirements || null);
+			setSoilType(plantSpecies.soilType || null);
+			setTemperatureMin(plantSpecies.temperatureRange?.min?.toString() ?? '');
+			setTemperatureMax(plantSpecies.temperatureRange?.max?.toString() ?? '');
+			setPhMin(plantSpecies.phRange?.min?.toString() ?? '');
+			setPhMax(plantSpecies.phRange?.max?.toString() ?? '');
+			setMatureSizeHeight(plantSpecies.matureSize?.height?.toString() ?? '');
+			setMatureSizeWidth(plantSpecies.matureSize?.width?.toString() ?? '');
+			setGrowthTime(plantSpecies.growthTime?.toString() ?? '');
+			setTags(plantSpecies.tags ?? []);
+		}
+		setFormErrors({});
+	};
+
+	const addTag = () => {
+		const trimmed = tagInput.trim();
+		if (trimmed && !tags.includes(trimmed)) {
+			setTags([...tags, trimmed]);
+			setTagInput('');
+		}
+	};
+
+	const removeTag = (tag: string) => {
+		setTags(tags.filter((t) => t !== tag));
+	};
+
+	const buildFormData = () => {
+		const data: Record<string, unknown> = {
+			commonName,
+			scientificName,
+			family: family || null,
+			description: description || null,
+			category,
+			difficulty,
+			growthRate,
+			lightRequirements,
+			waterRequirements,
+			humidityRequirements: humidityRequirements || null,
+			soilType: soilType || null,
+			tags: tags.length > 0 ? tags : null,
+		};
+
+		if (growthTime) data.growthTime = parseFloat(growthTime);
+
+		if (temperatureMin && temperatureMax) {
+			data.temperatureRange = {
+				min: parseFloat(temperatureMin),
+				max: parseFloat(temperatureMax),
+			};
+		}
+
+		if (phMin && phMax) {
+			data.phRange = {
+				min: parseFloat(phMin),
+				max: parseFloat(phMax),
+			};
+		}
+
+		if (matureSizeHeight && matureSizeWidth) {
+			data.matureSize = {
+				height: parseFloat(matureSizeHeight),
+				width: parseFloat(matureSizeWidth),
+			};
+		}
+
+		return data;
+	};
+
+	const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+		e.preventDefault();
+
+		if (!plantSpecies) return;
+
+		const data = buildFormData();
+		const result = updateSchema.safeParse(data);
+
+		if (!result.success) {
+			const errors: Record<string, { message?: string }> = {};
+			result.error.issues.forEach((err) => {
+				if (err.path[0]) {
+					errors[err.path[0] as string] = { message: err.message };
+				}
+			});
+			setFormErrors(errors);
+			return;
+		}
+
+		setFormErrors({});
+		await onSubmit(result.data);
+		if (!error) {
+			onOpenChange(false);
+		}
+	};
+
+	const handleOpenChange = (newOpen: boolean) => {
+		if (!newOpen) {
+			syncFromPlantSpecies();
+		}
+		onOpenChange(newOpen);
+	};
+
+	return {
+		commonName,
+		scientificName,
+		family,
+		description,
+		category,
+		difficulty,
+		growthRate,
+		lightRequirements,
+		waterRequirements,
+		humidityRequirements,
+		soilType,
+		temperatureMin,
+		temperatureMax,
+		phMin,
+		phMax,
+		matureSizeHeight,
+		matureSizeWidth,
+		growthTime,
+		tags,
+		tagInput,
+		formErrors,
+		setCommonName,
+		setScientificName,
+		setFamily,
+		setDescription,
+		setCategory,
+		setDifficulty,
+		setGrowthRate,
+		setLightRequirements,
+		setWaterRequirements,
+		setHumidityRequirements,
+		setSoilType,
+		setTemperatureMin,
+		setTemperatureMax,
+		setPhMin,
+		setPhMax,
+		setMatureSizeHeight,
+		setMatureSizeWidth,
+		setGrowthTime,
+		setTagInput,
+		addTag,
+		removeTag,
+		handleSubmit,
+		handleOpenChange,
+	};
+}

--- a/apps/web/features/plant-species/components/modals/PlantSpeciesCreateModal/PlantSpeciesCreateModal.tsx
+++ b/apps/web/features/plant-species/components/modals/PlantSpeciesCreateModal/PlantSpeciesCreateModal.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import type { PlantSpeciesCreateFormValues } from '@/features/plant-species/schemas/plant-species-create.schema';
+import { PlantSpeciesCreateForm } from '../../forms/PlantSpeciesCreateForm/PlantSpeciesCreateForm';
+
+interface PlantSpeciesCreateModalProps {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	onSubmit: (values: PlantSpeciesCreateFormValues) => Promise<void>;
+	isLoading: boolean;
+	error: Error | null;
+}
+
+export function PlantSpeciesCreateModal({
+	open,
+	onOpenChange,
+	onSubmit,
+	isLoading,
+	error,
+}: PlantSpeciesCreateModalProps) {
+	return (
+		<PlantSpeciesCreateForm
+			open={open}
+			onOpenChange={onOpenChange}
+			onSubmit={onSubmit}
+			isLoading={isLoading}
+			error={error}
+		/>
+	);
+}

--- a/apps/web/features/plant-species/components/modals/PlantSpeciesDeleteModal/PlantSpeciesDeleteModal.tsx
+++ b/apps/web/features/plant-species/components/modals/PlantSpeciesDeleteModal/PlantSpeciesDeleteModal.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import type { PlantSpeciesResponse } from '@/features/plant-species/api/types/plant-species-response.types';
+import {
+	AlertDialog,
+	AlertDialogAction,
+	AlertDialogCancel,
+	AlertDialogContent,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogHeader,
+	AlertDialogTitle,
+} from '@/shared/components/ui/alert-dialog';
+import { useTranslations } from 'next-intl';
+
+interface PlantSpeciesDeleteModalProps {
+	plantSpecies: PlantSpeciesResponse | null;
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	onConfirm: () => Promise<void>;
+	isLoading: boolean;
+}
+
+export function PlantSpeciesDeleteModal({
+	plantSpecies,
+	open,
+	onOpenChange,
+	onConfirm,
+	isLoading,
+}: PlantSpeciesDeleteModalProps) {
+	const t = useTranslations();
+
+	if (!plantSpecies) {
+		return null;
+	}
+
+	return (
+		<AlertDialog open={open} onOpenChange={onOpenChange}>
+			<AlertDialogContent>
+				<AlertDialogHeader>
+					<AlertDialogTitle>
+						{t('features.plantSpecies.list.actions.delete.confirm.title')}
+					</AlertDialogTitle>
+					<AlertDialogDescription>
+						{t(
+							'features.plantSpecies.list.actions.delete.confirm.description',
+							{ name: plantSpecies.commonName },
+						)}
+					</AlertDialogDescription>
+				</AlertDialogHeader>
+				<AlertDialogFooter>
+					<AlertDialogCancel disabled={isLoading}>
+						{t('common.cancel')}
+					</AlertDialogCancel>
+					<AlertDialogAction
+						onClick={onConfirm}
+						disabled={isLoading}
+						className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+					>
+						{isLoading
+							? t('features.plantSpecies.list.actions.delete.loading')
+							: t('common.delete')}
+					</AlertDialogAction>
+				</AlertDialogFooter>
+			</AlertDialogContent>
+		</AlertDialog>
+	);
+}

--- a/apps/web/features/plant-species/components/modals/PlantSpeciesDetailModal/PlantSpeciesDetailModal.tsx
+++ b/apps/web/features/plant-species/components/modals/PlantSpeciesDetailModal/PlantSpeciesDetailModal.tsx
@@ -1,0 +1,255 @@
+'use client';
+
+import type { PlantSpeciesResponse } from '@/features/plant-species/api/types/plant-species-response.types';
+import { PLANT_SPECIES_CATEGORIES } from '@/features/plant-species/constants/plant-species-categories';
+import { PLANT_SPECIES_DIFFICULTY } from '@/features/plant-species/constants/plant-species-difficulty';
+import {
+	PLANT_SPECIES_LIGHT_REQUIREMENTS,
+	PLANT_SPECIES_SOIL_TYPE,
+	PLANT_SPECIES_WATER_REQUIREMENTS,
+} from '@/features/plant-species/constants/plant-species-requirements';
+import {
+	formatGrowthTime,
+	formatMatureSize,
+	formatPhRange,
+	formatTemperatureRange,
+} from '@/features/plant-species/utils/plant-species-formatters';
+import { Badge } from '@/shared/components/ui/badge';
+import { Button } from '@/shared/components/ui/button';
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from '@/shared/components/ui/dialog';
+import { Separator } from '@/shared/components/ui/separator';
+import { useTranslations } from 'next-intl';
+
+interface PlantSpeciesDetailModalProps {
+	plantSpecies: PlantSpeciesResponse | null;
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	onEdit?: (plantSpecies: PlantSpeciesResponse) => void;
+}
+
+export function PlantSpeciesDetailModal({
+	plantSpecies,
+	open,
+	onOpenChange,
+	onEdit,
+}: PlantSpeciesDetailModalProps) {
+	const t = useTranslations();
+
+	if (!plantSpecies) {
+		return null;
+	}
+
+	const categoryInfo = PLANT_SPECIES_CATEGORIES[plantSpecies.category];
+	const difficultyInfo = PLANT_SPECIES_DIFFICULTY[plantSpecies.difficulty];
+	const lightInfo = PLANT_SPECIES_LIGHT_REQUIREMENTS[plantSpecies.lightRequirements];
+	const waterInfo = PLANT_SPECIES_WATER_REQUIREMENTS[plantSpecies.waterRequirements];
+
+	return (
+		<Dialog open={open} onOpenChange={onOpenChange}>
+			<DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
+				<DialogHeader>
+					<div className="flex items-start justify-between gap-4">
+						<div>
+							<DialogTitle className="text-xl">
+								{plantSpecies.commonName}
+							</DialogTitle>
+							<DialogDescription className="italic mt-1">
+								{plantSpecies.scientificName}
+							</DialogDescription>
+						</div>
+						<div className="flex gap-2 shrink-0">
+							<Badge variant="secondary">
+								{categoryInfo.icon} {categoryInfo.label}
+							</Badge>
+							{plantSpecies.isVerified && (
+								<Badge variant="default">
+									{t('features.plantSpecies.verified')}
+								</Badge>
+							)}
+						</div>
+					</div>
+				</DialogHeader>
+
+				<div className="space-y-4">
+					{/* Description */}
+					{plantSpecies.description && (
+						<div>
+							<p className="text-sm text-muted-foreground">
+								{plantSpecies.description}
+							</p>
+						</div>
+					)}
+
+					{plantSpecies.family && (
+						<div className="text-sm">
+							<span className="font-medium">{t('shared.fields.family.label')}: </span>
+							<span className="text-muted-foreground">{plantSpecies.family}</span>
+						</div>
+					)}
+
+					<Separator />
+
+					{/* Care Overview */}
+					<div>
+						<h4 className="text-sm font-semibold mb-3">
+							{t('features.plantSpecies.sections.careOverview')}
+						</h4>
+						<div className="grid grid-cols-2 gap-3">
+							<div className="flex items-center gap-2 text-sm">
+								<span className="text-lg">{difficultyInfo.icon}</span>
+								<div>
+									<div className="font-medium">{t('shared.fields.difficulty.label')}</div>
+									<div className="text-muted-foreground">{difficultyInfo.label}</div>
+								</div>
+							</div>
+
+							<div className="flex items-center gap-2 text-sm">
+								<span className="text-lg">{lightInfo.icon}</span>
+								<div>
+									<div className="font-medium">{t('shared.fields.lightRequirements.label')}</div>
+									<div className="text-muted-foreground">{lightInfo.label}</div>
+								</div>
+							</div>
+
+							<div className="flex items-center gap-2 text-sm">
+								<span className="text-lg">{waterInfo.icon}</span>
+								<div>
+									<div className="font-medium">{t('shared.fields.waterRequirements.label')}</div>
+									<div className="text-muted-foreground">{waterInfo.label}</div>
+								</div>
+							</div>
+
+							{plantSpecies.humidityRequirements && (
+								<div className="flex items-center gap-2 text-sm">
+									<span className="text-lg">💨</span>
+									<div>
+										<div className="font-medium">{t('shared.fields.humidityRequirements.label')}</div>
+										<div className="text-muted-foreground">
+											{plantSpecies.humidityRequirements}
+										</div>
+									</div>
+								</div>
+							)}
+						</div>
+					</div>
+
+					{/* Growth Info */}
+					<Separator />
+					<div>
+						<h4 className="text-sm font-semibold mb-3">
+							{t('features.plantSpecies.sections.growthInfo')}
+						</h4>
+						<div className="grid grid-cols-2 gap-3 text-sm">
+							<div>
+								<div className="font-medium">{t('shared.fields.growthRate.label')}</div>
+								<div className="text-muted-foreground">
+									{plantSpecies.growthRate}
+								</div>
+							</div>
+
+							{plantSpecies.growthTime && (
+								<div>
+									<div className="font-medium">{t('shared.fields.growthTime.label')}</div>
+									<div className="text-muted-foreground">
+										{formatGrowthTime(plantSpecies.growthTime)}
+									</div>
+								</div>
+							)}
+
+							{plantSpecies.matureSize && (
+								<div>
+									<div className="font-medium">{t('shared.fields.matureSize.label')}</div>
+									<div className="text-muted-foreground">
+										{formatMatureSize(plantSpecies.matureSize)}
+									</div>
+								</div>
+							)}
+						</div>
+					</div>
+
+					{/* Environmental Conditions */}
+					{(plantSpecies.temperatureRange ||
+						plantSpecies.phRange ||
+						plantSpecies.soilType) && (
+						<>
+							<Separator />
+							<div>
+								<h4 className="text-sm font-semibold mb-3">
+									{t('features.plantSpecies.sections.environmentalConditions')}
+								</h4>
+								<div className="grid grid-cols-2 gap-3 text-sm">
+									{plantSpecies.temperatureRange && (
+										<div>
+											<div className="font-medium">
+												{t('shared.fields.temperatureRange.label')}
+											</div>
+											<div className="text-muted-foreground">
+												{formatTemperatureRange(plantSpecies.temperatureRange)}
+											</div>
+										</div>
+									)}
+
+									{plantSpecies.phRange && (
+										<div>
+											<div className="font-medium">{t('shared.fields.phRange.label')}</div>
+											<div className="text-muted-foreground">
+												{formatPhRange(plantSpecies.phRange)}
+											</div>
+										</div>
+									)}
+
+									{plantSpecies.soilType && (
+										<div>
+											<div className="font-medium">{t('shared.fields.soilType.label')}</div>
+											<div className="text-muted-foreground">
+												{PLANT_SPECIES_SOIL_TYPE[plantSpecies.soilType].icon}{' '}
+												{PLANT_SPECIES_SOIL_TYPE[plantSpecies.soilType].label}
+											</div>
+										</div>
+									)}
+								</div>
+							</div>
+						</>
+					)}
+
+					{/* Tags */}
+					{plantSpecies.tags && plantSpecies.tags.length > 0 && (
+						<>
+							<Separator />
+							<div>
+								<h4 className="text-sm font-semibold mb-2">
+									{t('shared.fields.tags.label')}
+								</h4>
+								<div className="flex flex-wrap gap-2">
+									{plantSpecies.tags.map((tag) => (
+										<Badge key={tag} variant="outline">
+											{tag}
+										</Badge>
+									))}
+								</div>
+							</div>
+						</>
+					)}
+				</div>
+
+				<DialogFooter>
+					<Button variant="outline" onClick={() => onOpenChange(false)}>
+						{t('common.close')}
+					</Button>
+					{onEdit && (
+						<Button onClick={() => onEdit(plantSpecies)}>
+							{t('common.edit')}
+						</Button>
+					)}
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/apps/web/features/plant-species/components/tables/PlantSpeciesTable/PlantSpeciesTable.tsx
+++ b/apps/web/features/plant-species/components/tables/PlantSpeciesTable/PlantSpeciesTable.tsx
@@ -1,0 +1,162 @@
+'use client';
+
+import type { PlantSpeciesResponse } from '@/features/plant-species/api/types/plant-species-response.types';
+import { Button } from '@/shared/components/ui/button';
+import { Input } from '@/shared/components/ui/input';
+import { Skeleton } from '@/shared/components/ui/skeleton';
+import {
+	Table,
+	TableBody,
+	TableHead,
+	TableHeader,
+	TableRow,
+} from '@/shared/components/ui/table';
+import { SearchIcon } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+import { PlantSpeciesTableRow } from './PlantSpeciesTableRow';
+
+interface PlantSpeciesTableProps {
+	plantSpecies: PlantSpeciesResponse[];
+	isLoading?: boolean;
+	searchValue?: string;
+	onSearchChange?: (value: string) => void;
+	page?: number;
+	totalPages?: number;
+	onPageChange?: (page: number) => void;
+	onView?: (plantSpecies: PlantSpeciesResponse) => void;
+	onEdit?: (plantSpecies: PlantSpeciesResponse) => void;
+	onDelete?: (id: string) => void;
+}
+
+export function PlantSpeciesTable({
+	plantSpecies,
+	isLoading = false,
+	searchValue = '',
+	onSearchChange,
+	page = 1,
+	totalPages = 1,
+	onPageChange,
+	onView,
+	onEdit,
+	onDelete,
+}: PlantSpeciesTableProps) {
+	const t = useTranslations();
+
+	return (
+		<div className="space-y-4">
+			{/* Search */}
+			{onSearchChange && (
+				<div className="relative">
+					<SearchIcon className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+					<Input
+						placeholder={t('features.plantSpecies.list.searchPlaceholder')}
+						value={searchValue}
+						onChange={(e) => onSearchChange(e.target.value)}
+						className="pl-9"
+					/>
+				</div>
+			)}
+
+			{/* Table */}
+			<div className="rounded-md border">
+				<Table>
+					<TableHeader>
+						<TableRow>
+							<TableHead className="w-16">
+								{t('features.plantSpecies.list.table.columns.image')}
+							</TableHead>
+							<TableHead>
+								{t('features.plantSpecies.list.table.columns.name')}
+							</TableHead>
+							<TableHead>
+								{t('features.plantSpecies.list.table.columns.category')}
+							</TableHead>
+							<TableHead>
+								{t('features.plantSpecies.list.table.columns.difficulty')}
+							</TableHead>
+							<TableHead>
+								{t('features.plantSpecies.list.table.columns.status')}
+							</TableHead>
+							<TableHead className="w-16">
+								{t('features.plantSpecies.list.table.columns.actions')}
+							</TableHead>
+						</TableRow>
+					</TableHeader>
+					<TableBody>
+						{isLoading ? (
+							Array.from({ length: 5 }).map((_, i) => (
+								<TableRow key={i}>
+									<td className="p-4">
+										<Skeleton className="h-10 w-10 rounded-md" />
+									</td>
+									<td className="p-4">
+										<Skeleton className="h-4 w-32 mb-2" />
+										<Skeleton className="h-3 w-24" />
+									</td>
+									<td className="p-4">
+										<Skeleton className="h-5 w-20" />
+									</td>
+									<td className="p-4">
+										<Skeleton className="h-5 w-16" />
+									</td>
+									<td className="p-4">
+										<Skeleton className="h-5 w-20" />
+									</td>
+									<td className="p-4">
+										<Skeleton className="h-8 w-8 rounded-md" />
+									</td>
+								</TableRow>
+							))
+						) : plantSpecies.length === 0 ? (
+							<TableRow>
+								<td
+									colSpan={6}
+									className="text-center py-8 text-muted-foreground text-sm"
+								>
+									{t('features.plantSpecies.list.empty')}
+								</td>
+							</TableRow>
+						) : (
+							plantSpecies.map((species) => (
+								<PlantSpeciesTableRow
+									key={species.id}
+									plantSpecies={species}
+									onView={onView}
+									onEdit={onEdit}
+									onDelete={onDelete}
+								/>
+							))
+						)}
+					</TableBody>
+				</Table>
+			</div>
+
+			{/* Pagination */}
+			{totalPages > 1 && onPageChange && (
+				<div className="flex items-center justify-between">
+					<div className="text-sm text-muted-foreground">
+						{t('common.pagination.page', { page, totalPages })}
+					</div>
+					<div className="flex gap-2">
+						<Button
+							variant="outline"
+							size="sm"
+							onClick={() => onPageChange(page - 1)}
+							disabled={page <= 1}
+						>
+							{t('common.pagination.previous')}
+						</Button>
+						<Button
+							variant="outline"
+							size="sm"
+							onClick={() => onPageChange(page + 1)}
+							disabled={page >= totalPages}
+						>
+							{t('common.pagination.next')}
+						</Button>
+					</div>
+				</div>
+			)}
+		</div>
+	);
+}

--- a/apps/web/features/plant-species/components/tables/PlantSpeciesTable/PlantSpeciesTableRow.tsx
+++ b/apps/web/features/plant-species/components/tables/PlantSpeciesTable/PlantSpeciesTableRow.tsx
@@ -1,0 +1,131 @@
+'use client';
+
+import type { PlantSpeciesResponse } from '@/features/plant-species/api/types/plant-species-response.types';
+import { PLANT_SPECIES_CATEGORIES } from '@/features/plant-species/constants/plant-species-categories';
+import { PLANT_SPECIES_DIFFICULTY } from '@/features/plant-species/constants/plant-species-difficulty';
+import { Badge } from '@/shared/components/ui/badge';
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuTrigger,
+} from '@/shared/components/ui/dropdown-menu';
+import { TableCell, TableRow } from '@/shared/components/ui/table';
+import { MoreVerticalIcon } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+
+interface PlantSpeciesTableRowProps {
+	plantSpecies: PlantSpeciesResponse;
+	onView?: (plantSpecies: PlantSpeciesResponse) => void;
+	onEdit?: (plantSpecies: PlantSpeciesResponse) => void;
+	onDelete?: (id: string) => void;
+}
+
+export function PlantSpeciesTableRow({
+	plantSpecies,
+	onView,
+	onEdit,
+	onDelete,
+}: PlantSpeciesTableRowProps) {
+	const t = useTranslations();
+
+	const categoryInfo = PLANT_SPECIES_CATEGORIES[plantSpecies.category];
+	const difficultyInfo = PLANT_SPECIES_DIFFICULTY[plantSpecies.difficulty];
+
+	const handleRowClick = () => {
+		onView?.(plantSpecies);
+	};
+
+	const handleActionClick = (e: React.MouseEvent) => {
+		e.stopPropagation();
+	};
+
+	const getDifficultyVariant = (): 'default' | 'secondary' | 'destructive' | 'outline' => {
+		switch (plantSpecies.difficulty) {
+			case 'EASY':
+				return 'secondary';
+			case 'MEDIUM':
+				return 'outline';
+			case 'HARD':
+				return 'destructive';
+			default:
+				return 'secondary';
+		}
+	};
+
+	return (
+		<TableRow
+			className="cursor-pointer hover:bg-muted/50 transition-colors"
+			onClick={handleRowClick}
+		>
+			<TableCell>
+				<div className="h-10 w-10 rounded-md bg-muted flex items-center justify-center text-lg">
+					{categoryInfo.icon}
+				</div>
+			</TableCell>
+
+			<TableCell>
+				<div>
+					<div className="font-medium">{plantSpecies.commonName}</div>
+					<div className="text-sm text-muted-foreground italic">
+						{plantSpecies.scientificName}
+					</div>
+				</div>
+			</TableCell>
+
+			<TableCell>
+				<Badge variant="secondary" className="text-xs">
+					{categoryInfo.icon} {categoryInfo.label}
+				</Badge>
+			</TableCell>
+
+			<TableCell>
+				<Badge variant={getDifficultyVariant()} className="text-xs">
+					{difficultyInfo.icon} {difficultyInfo.label}
+				</Badge>
+			</TableCell>
+
+			<TableCell>
+				{plantSpecies.isVerified ? (
+					<Badge variant="default" className="text-xs">
+						{t('features.plantSpecies.verified')}
+					</Badge>
+				) : (
+					<Badge variant="outline" className="text-xs">
+						{t('features.plantSpecies.unverified')}
+					</Badge>
+				)}
+			</TableCell>
+
+			<TableCell onClick={handleActionClick}>
+				<DropdownMenu>
+					<DropdownMenuTrigger asChild>
+						<button className="h-8 w-8 inline-flex items-center justify-center rounded-md hover:bg-accent">
+							<MoreVerticalIcon className="h-4 w-4" />
+						</button>
+					</DropdownMenuTrigger>
+					<DropdownMenuContent align="end">
+						{onView && (
+							<DropdownMenuItem onClick={() => onView(plantSpecies)}>
+								{t('features.plantSpecies.list.actions.view')}
+							</DropdownMenuItem>
+						)}
+						{onEdit && (
+							<DropdownMenuItem onClick={() => onEdit(plantSpecies)}>
+								{t('features.plantSpecies.list.actions.edit')}
+							</DropdownMenuItem>
+						)}
+						{onDelete && (
+							<DropdownMenuItem
+								onClick={() => onDelete(plantSpecies.id)}
+								className="text-destructive"
+							>
+								{t('features.plantSpecies.list.actions.delete.label')}
+							</DropdownMenuItem>
+						)}
+					</DropdownMenuContent>
+				</DropdownMenu>
+			</TableCell>
+		</TableRow>
+	);
+}


### PR DESCRIPTION
Implements all organism components for the Plant Species Context as described in #170.

## Changes

- Forms: PlantSpeciesCreateForm + hook, PlantSpeciesUpdateForm + hook
- Modals: PlantSpeciesCreateModal, PlantSpeciesDetailModal, PlantSpeciesDeleteModal
- Tables: PlantSpeciesTable (with search, pagination, loading skeletons), PlantSpeciesTableRow
- Cards: PlantSpeciesCard, PlantSpeciesDetailCard (tabbed)

Closes #170

Generated with [Claude Code](https://claude.ai/code)