### PR TITLE
feat(web): Plant Species Context - Page Components and Routes

### DIFF
--- a/apps/web/app/[locale]/plant-species/[id]/page.tsx
+++ b/apps/web/app/[locale]/plant-species/[id]/page.tsx
@@ -1,0 +1,7 @@
+import { PlantSpeciesDetailPage } from 'features/plant-species/components/pages/PlantSpeciesDetailPage/PlantSpeciesDetailPage';
+
+const Page = () => {
+	return <PlantSpeciesDetailPage />;
+};
+
+export default Page;

--- a/apps/web/app/[locale]/plant-species/page.tsx
+++ b/apps/web/app/[locale]/plant-species/page.tsx
@@ -1,0 +1,7 @@
+import { PlantSpeciesListPage } from 'features/plant-species/components/pages/PlantSpeciesListPage/PlantSpeciesListPage';
+
+const Page = () => {
+	return <PlantSpeciesListPage />;
+};
+
+export default Page;

--- a/apps/web/features/plant-species/components/pages/PlantSpeciesDetailPage/PlantSpeciesDetailPage.tsx
+++ b/apps/web/features/plant-species/components/pages/PlantSpeciesDetailPage/PlantSpeciesDetailPage.tsx
@@ -1,0 +1,152 @@
+'use client';
+
+import { PlantSpeciesDetailCard } from '@/features/plant-species/components/cards/PlantSpeciesDetailCard/PlantSpeciesDetailCard';
+import { PlantSpeciesDeleteModal } from '@/features/plant-species/components/modals/PlantSpeciesDeleteModal/PlantSpeciesDeleteModal';
+import { PlantSpeciesUpdateForm } from '@/features/plant-species/components/forms/PlantSpeciesUpdateForm/PlantSpeciesUpdateForm';
+import { usePlantSpeciesDetailPage } from '@/features/plant-species/hooks/pages/usePlantSpeciesDetailPage';
+import type { PlantSpeciesUpdateFormValues } from '@/features/plant-species/schemas/plant-species-update.schema';
+import { Button } from '@/shared/components/ui/button';
+import { Skeleton } from '@/shared/components/ui/skeleton';
+import { ChevronRightIcon, PencilIcon, Trash2Icon } from 'lucide-react';
+import { useLocale, useTranslations } from 'next-intl';
+import Link from 'next/link';
+import { useParams } from 'next/navigation';
+import { useCallback, useState } from 'react';
+
+export function PlantSpeciesDetailPage() {
+	const t = useTranslations();
+	const locale = useLocale();
+	const params = useParams();
+	const id = params?.id as string;
+
+	const {
+		plantSpecies,
+		isLoading,
+		error,
+		handleUpdate,
+		handleDelete,
+		isUpdating,
+		isDeleting,
+	} = usePlantSpeciesDetailPage(id);
+
+	// Dialog state
+	const [updateDialogOpen, setUpdateDialogOpen] = useState(false);
+	const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+
+	const handleUpdateSubmit = useCallback(
+		async (values: PlantSpeciesUpdateFormValues) => {
+			await handleUpdate(
+				values as Parameters<typeof handleUpdate>[0],
+			);
+			setUpdateDialogOpen(false);
+		},
+		[handleUpdate],
+	);
+
+	const handleDeleteConfirm = useCallback(async () => {
+		await handleDelete();
+	}, [handleDelete]);
+
+	// Loading state
+	if (isLoading || plantSpecies === undefined) {
+		return (
+			<div className="mx-auto space-y-6">
+				<div className="flex items-center gap-2">
+					<Skeleton className="h-4 w-24" />
+					<Skeleton className="h-4 w-4" />
+					<Skeleton className="h-4 w-32" />
+				</div>
+				<div className="flex items-center justify-between">
+					<Skeleton className="h-8 w-48" />
+					<div className="flex gap-2">
+						<Skeleton className="h-9 w-20" />
+						<Skeleton className="h-9 w-20" />
+					</div>
+				</div>
+				<Skeleton className="h-96 w-full" />
+			</div>
+		);
+	}
+
+	// Error state
+	if (error || !plantSpecies) {
+		return (
+			<div className="mx-auto py-8">
+				<div className="flex items-center justify-center min-h-[400px]">
+					<p className="text-destructive">
+						{error
+							? t('features.plantSpecies.detail.error.loading', {
+									message: (error as Error)?.message ?? 'Unknown error',
+								})
+							: t('features.plantSpecies.detail.notFound')}
+					</p>
+				</div>
+			</div>
+		);
+	}
+
+	return (
+		<div className="mx-auto space-y-6">
+			{/* Breadcrumbs */}
+			<nav className="flex items-center gap-1.5 text-sm text-muted-foreground">
+				<Link
+					href={`/${locale}/plant-species`}
+					className="hover:text-foreground transition-colors"
+				>
+					{t('features.plantSpecies.detail.breadcrumbs.speciesLibrary')}
+				</Link>
+				<ChevronRightIcon className="h-4 w-4" />
+				<span className="text-foreground font-medium">
+					{plantSpecies.commonName}
+				</span>
+			</nav>
+
+			{/* Header with actions */}
+			<div className="flex items-center justify-between gap-4">
+				<h1 className="text-2xl font-bold">{plantSpecies.commonName}</h1>
+				<div className="flex gap-2 shrink-0">
+					<Button
+						variant="outline"
+						onClick={() => setUpdateDialogOpen(true)}
+					>
+						<PencilIcon className="mr-2 h-4 w-4" />
+						{t('features.plantSpecies.detail.actions.edit')}
+					</Button>
+					<Button
+						variant="destructive"
+						onClick={() => setDeleteDialogOpen(true)}
+					>
+						<Trash2Icon className="mr-2 h-4 w-4" />
+						{t('features.plantSpecies.detail.actions.delete')}
+					</Button>
+				</div>
+			</div>
+
+			{/* Detail Card */}
+			<PlantSpeciesDetailCard
+				plantSpecies={plantSpecies}
+				onEdit={() => setUpdateDialogOpen(true)}
+				onDelete={() => setDeleteDialogOpen(true)}
+			/>
+
+			{/* Update Form */}
+			<PlantSpeciesUpdateForm
+				plantSpecies={plantSpecies}
+				open={updateDialogOpen}
+				onOpenChange={setUpdateDialogOpen}
+				onSubmit={handleUpdateSubmit}
+				isLoading={isUpdating}
+				error={null}
+			/>
+
+			{/* Delete Modal */}
+			<PlantSpeciesDeleteModal
+				plantSpecies={plantSpecies}
+				open={deleteDialogOpen}
+				onOpenChange={setDeleteDialogOpen}
+				onConfirm={handleDeleteConfirm}
+				isLoading={isDeleting}
+			/>
+		</div>
+	);
+}

--- a/apps/web/features/plant-species/components/pages/PlantSpeciesDetailPage/PlantSpeciesDetailPage.tsx
+++ b/apps/web/features/plant-species/components/pages/PlantSpeciesDetailPage/PlantSpeciesDetailPage.tsx
@@ -5,13 +5,11 @@ import { PlantSpeciesDeleteModal } from '@/features/plant-species/components/mod
 import { PlantSpeciesUpdateForm } from '@/features/plant-species/components/forms/PlantSpeciesUpdateForm/PlantSpeciesUpdateForm';
 import { usePlantSpeciesDetailPage } from '@/features/plant-species/hooks/pages/usePlantSpeciesDetailPage';
 import type { PlantSpeciesUpdateFormValues } from '@/features/plant-species/schemas/plant-species-update.schema';
-import { Button } from '@/shared/components/ui/button';
 import { Skeleton } from '@/shared/components/ui/skeleton';
-import { ChevronRightIcon, PencilIcon, Trash2Icon } from 'lucide-react';
+import { ChevronRightIcon } from 'lucide-react';
 import { useLocale, useTranslations } from 'next-intl';
 import Link from 'next/link';
 import { useParams } from 'next/navigation';
-import { useCallback, useState } from 'react';
 
 export function PlantSpeciesDetailPage() {
 	const t = useTranslations();
@@ -27,27 +25,12 @@ export function PlantSpeciesDetailPage() {
 		handleDelete,
 		isUpdating,
 		isDeleting,
+		updateDialogOpen,
+		setUpdateDialogOpen,
+		deleteDialogOpen,
+		setDeleteDialogOpen,
 	} = usePlantSpeciesDetailPage(id);
 
-	// Dialog state
-	const [updateDialogOpen, setUpdateDialogOpen] = useState(false);
-	const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
-
-	const handleUpdateSubmit = useCallback(
-		async (values: PlantSpeciesUpdateFormValues) => {
-			await handleUpdate(
-				values as Parameters<typeof handleUpdate>[0],
-			);
-			setUpdateDialogOpen(false);
-		},
-		[handleUpdate],
-	);
-
-	const handleDeleteConfirm = useCallback(async () => {
-		await handleDelete();
-	}, [handleDelete]);
-
-	// Loading state
 	if (isLoading || plantSpecies === undefined) {
 		return (
 			<div className="mx-auto space-y-6">
@@ -56,19 +39,11 @@ export function PlantSpeciesDetailPage() {
 					<Skeleton className="h-4 w-4" />
 					<Skeleton className="h-4 w-32" />
 				</div>
-				<div className="flex items-center justify-between">
-					<Skeleton className="h-8 w-48" />
-					<div className="flex gap-2">
-						<Skeleton className="h-9 w-20" />
-						<Skeleton className="h-9 w-20" />
-					</div>
-				</div>
 				<Skeleton className="h-96 w-full" />
 			</div>
 		);
 	}
 
-	// Error state
 	if (error || !plantSpecies) {
 		return (
 			<div className="mx-auto py-8">
@@ -87,7 +62,6 @@ export function PlantSpeciesDetailPage() {
 
 	return (
 		<div className="mx-auto space-y-6">
-			{/* Breadcrumbs */}
 			<nav className="flex items-center gap-1.5 text-sm text-muted-foreground">
 				<Link
 					href={`/${locale}/plant-species`}
@@ -101,50 +75,28 @@ export function PlantSpeciesDetailPage() {
 				</span>
 			</nav>
 
-			{/* Header with actions */}
-			<div className="flex items-center justify-between gap-4">
-				<h1 className="text-2xl font-bold">{plantSpecies.commonName}</h1>
-				<div className="flex gap-2 shrink-0">
-					<Button
-						variant="outline"
-						onClick={() => setUpdateDialogOpen(true)}
-					>
-						<PencilIcon className="mr-2 h-4 w-4" />
-						{t('features.plantSpecies.detail.actions.edit')}
-					</Button>
-					<Button
-						variant="destructive"
-						onClick={() => setDeleteDialogOpen(true)}
-					>
-						<Trash2Icon className="mr-2 h-4 w-4" />
-						{t('features.plantSpecies.detail.actions.delete')}
-					</Button>
-				</div>
-			</div>
-
-			{/* Detail Card */}
 			<PlantSpeciesDetailCard
 				plantSpecies={plantSpecies}
 				onEdit={() => setUpdateDialogOpen(true)}
 				onDelete={() => setDeleteDialogOpen(true)}
 			/>
 
-			{/* Update Form */}
 			<PlantSpeciesUpdateForm
 				plantSpecies={plantSpecies}
 				open={updateDialogOpen}
 				onOpenChange={setUpdateDialogOpen}
-				onSubmit={handleUpdateSubmit}
+				onSubmit={(values: PlantSpeciesUpdateFormValues) =>
+					handleUpdate(values as Parameters<typeof handleUpdate>[0])
+				}
 				isLoading={isUpdating}
 				error={null}
 			/>
 
-			{/* Delete Modal */}
 			<PlantSpeciesDeleteModal
 				plantSpecies={plantSpecies}
 				open={deleteDialogOpen}
 				onOpenChange={setDeleteDialogOpen}
-				onConfirm={handleDeleteConfirm}
+				onConfirm={handleDelete}
 				isLoading={isDeleting}
 			/>
 		</div>

--- a/apps/web/features/plant-species/components/pages/PlantSpeciesListPage/PlantSpeciesListPage.tsx
+++ b/apps/web/features/plant-species/components/pages/PlantSpeciesListPage/PlantSpeciesListPage.tsx
@@ -98,8 +98,8 @@ export function PlantSpeciesListPage() {
 			if (!selectedSpecies) return;
 			await handleUpdate(
 				{
-					id: selectedSpecies.id,
 					...(values as Parameters<typeof handleUpdate>[0]),
+					id: selectedSpecies.id,
 				},
 				() => {
 					setUpdateDialogOpen(false);

--- a/apps/web/features/plant-species/components/pages/PlantSpeciesListPage/PlantSpeciesListPage.tsx
+++ b/apps/web/features/plant-species/components/pages/PlantSpeciesListPage/PlantSpeciesListPage.tsx
@@ -1,0 +1,389 @@
+'use client';
+
+import type { PlantSpeciesResponse } from '@/features/plant-species/api/types/plant-species-response.types';
+import {
+	PlantSpeciesCategory,
+	PlantSpeciesDifficulty,
+} from '@/features/plant-species/api/types/plant-species.types';
+import { PlantSpeciesCard } from '@/features/plant-species/components/cards/PlantSpeciesCard/PlantSpeciesCard';
+import { PlantSpeciesCreateModal } from '@/features/plant-species/components/modals/PlantSpeciesCreateModal/PlantSpeciesCreateModal';
+import { PlantSpeciesDeleteModal } from '@/features/plant-species/components/modals/PlantSpeciesDeleteModal/PlantSpeciesDeleteModal';
+import { PlantSpeciesUpdateForm } from '@/features/plant-species/components/forms/PlantSpeciesUpdateForm/PlantSpeciesUpdateForm';
+import { PlantSpeciesTable } from '@/features/plant-species/components/tables/PlantSpeciesTable/PlantSpeciesTable';
+import { PLANT_SPECIES_CATEGORIES } from '@/features/plant-species/constants/plant-species-categories';
+import { PLANT_SPECIES_DIFFICULTY } from '@/features/plant-species/constants/plant-species-difficulty';
+import { usePlantSpeciesCreate } from '@/features/plant-species/hooks/use-plant-species-create/use-plant-species-create';
+import { usePlantSpeciesDelete } from '@/features/plant-species/hooks/use-plant-species-delete/use-plant-species-delete';
+import { usePlantSpeciesUpdate } from '@/features/plant-species/hooks/use-plant-species-update/use-plant-species-update';
+import { usePlantSpeciesListPage } from '@/features/plant-species/hooks/pages/usePlantSpeciesListPage';
+import type { PlantSpeciesCreateFormValues } from '@/features/plant-species/schemas/plant-species-create.schema';
+import type { PlantSpeciesUpdateFormValues } from '@/features/plant-species/schemas/plant-species-update.schema';
+import { PageHeader } from '@/shared/components/organisms/page-header';
+import { Button } from '@/shared/components/ui/button';
+import { Checkbox } from '@/shared/components/ui/checkbox';
+import { Input } from '@/shared/components/ui/input';
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from '@/shared/components/ui/select';
+import { Skeleton } from '@/shared/components/ui/skeleton';
+import { LayoutGridIcon, ListIcon, PlusIcon, SearchIcon } from 'lucide-react';
+import { useLocale, useTranslations } from 'next-intl';
+import { useRouter } from 'next/navigation';
+import { useCallback, useState } from 'react';
+import { toast } from 'sonner';
+
+export function PlantSpeciesListPage() {
+	const t = useTranslations();
+	const locale = useLocale();
+	const router = useRouter();
+
+	const {
+		species,
+		isLoading,
+		error,
+		filters,
+		handleFilterChange,
+		handleClearFilters,
+		viewMode,
+		setViewMode,
+	} = usePlantSpeciesListPage();
+
+	// Dialog state
+	const [createDialogOpen, setCreateDialogOpen] = useState(false);
+	const [updateDialogOpen, setUpdateDialogOpen] = useState(false);
+	const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+	const [selectedSpecies, setSelectedSpecies] =
+		useState<PlantSpeciesResponse | null>(null);
+	const [selectedDeleteSpecies, setSelectedDeleteSpecies] =
+		useState<PlantSpeciesResponse | null>(null);
+
+	// CRUD hooks
+	const {
+		handleCreate,
+		isLoading: isCreating,
+		error: createError,
+	} = usePlantSpeciesCreate();
+	const {
+		handleUpdate,
+		isLoading: isUpdating,
+		error: updateError,
+	} = usePlantSpeciesUpdate();
+	const { handleDelete, isLoading: isDeleting } = usePlantSpeciesDelete();
+
+	// Handlers
+	const handleCreateSubmit = useCallback(
+		async (values: PlantSpeciesCreateFormValues) => {
+			await handleCreate(
+				values as Parameters<typeof handleCreate>[0],
+				() => {
+					setCreateDialogOpen(false);
+					toast.success(
+						t('features.plantSpecies.list.actions.create.success'),
+					);
+				},
+				() => {
+					toast.error(t('features.plantSpecies.list.actions.create.error'));
+				},
+			);
+		},
+		[handleCreate, t],
+	);
+
+	const handleUpdateSubmit = useCallback(
+		async (values: PlantSpeciesUpdateFormValues) => {
+			if (!selectedSpecies) return;
+			await handleUpdate(
+				{
+					id: selectedSpecies.id,
+					...(values as Parameters<typeof handleUpdate>[0]),
+				},
+				() => {
+					setUpdateDialogOpen(false);
+					setSelectedSpecies(null);
+					toast.success(
+						t('features.plantSpecies.list.actions.update.success'),
+					);
+				},
+				() => {
+					toast.error(t('features.plantSpecies.list.actions.update.error'));
+				},
+			);
+		},
+		[handleUpdate, selectedSpecies, t],
+	);
+
+	const handleDeleteConfirm = useCallback(async () => {
+		if (!selectedDeleteSpecies) return;
+		await handleDelete(
+			selectedDeleteSpecies.id,
+			() => {
+				setDeleteDialogOpen(false);
+				setSelectedDeleteSpecies(null);
+				toast.success(
+					t('features.plantSpecies.list.actions.delete.success'),
+				);
+			},
+			() => {
+				toast.error(t('features.plantSpecies.list.actions.delete.error'));
+			},
+		);
+	}, [handleDelete, selectedDeleteSpecies, t]);
+
+	const handleEditClick = useCallback((ps: PlantSpeciesResponse) => {
+		setSelectedSpecies(ps);
+		setUpdateDialogOpen(true);
+	}, []);
+
+	const handleDeleteClick = useCallback((id: string) => {
+		const ps = species.find((s) => s.id === id) ?? null;
+		setSelectedDeleteSpecies(ps);
+		setDeleteDialogOpen(true);
+	}, [species]);
+
+	const handleViewClick = useCallback(
+		(ps: PlantSpeciesResponse) => {
+			router.push(`/${locale}/plant-species/${ps.id}`);
+		},
+		[router, locale],
+	);
+
+	const hasActiveFilters =
+		filters.category !== undefined ||
+		filters.difficulty !== undefined ||
+		filters.search !== '' ||
+		filters.verifiedOnly;
+
+	// Loading state
+	if (isLoading) {
+		return (
+			<div className="mx-auto space-y-6">
+				<div className="flex items-center justify-between">
+					<Skeleton className="h-8 w-48" />
+					<Skeleton className="h-9 w-32" />
+				</div>
+				<div className="flex gap-3">
+					<Skeleton className="h-9 flex-1" />
+					<Skeleton className="h-9 w-40" />
+					<Skeleton className="h-9 w-36" />
+					<Skeleton className="h-9 w-28" />
+				</div>
+				<div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
+					{Array.from({ length: 8 }).map((_, i) => (
+						<Skeleton key={i} className="h-64" />
+					))}
+				</div>
+			</div>
+		);
+	}
+
+	// Error state
+	if (error) {
+		return (
+			<div className="mx-auto py-8">
+				<div className="flex items-center justify-center min-h-[400px]">
+					<p className="text-destructive">
+						{t('features.plantSpecies.list.error.loading', {
+							message: (error as Error)?.message ?? 'Unknown error',
+						})}
+					</p>
+				</div>
+			</div>
+		);
+	}
+
+	return (
+		<div className="mx-auto space-y-6">
+			{/* Header */}
+			<PageHeader
+				title={t('features.plantSpecies.list.title')}
+				description={t('features.plantSpecies.list.description')}
+				actions={[
+					<Button key="create" onClick={() => setCreateDialogOpen(true)}>
+						<PlusIcon className="mr-2 h-4 w-4" />
+						{t('features.plantSpecies.list.actions.create.button')}
+					</Button>,
+				]}
+			/>
+
+			{/* Filters */}
+			<div className="flex flex-wrap gap-3 items-center">
+				{/* Search */}
+				<div className="relative flex-1 min-w-[200px]">
+					<SearchIcon className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+					<Input
+						placeholder={t('features.plantSpecies.list.searchPlaceholder')}
+						value={filters.search}
+						onChange={(e) => handleFilterChange('search', e.target.value)}
+						className="pl-9"
+					/>
+				</div>
+
+				{/* Category filter */}
+				<Select
+					value={filters.category ?? 'all'}
+					onValueChange={(v) =>
+						handleFilterChange(
+							'category',
+							v === 'all' ? undefined : (v as PlantSpeciesCategory),
+						)
+					}
+				>
+					<SelectTrigger className="w-44">
+						<SelectValue
+							placeholder={t(
+								'features.plantSpecies.list.filters.allCategories',
+							)}
+						/>
+					</SelectTrigger>
+					<SelectContent>
+						<SelectItem value="all">
+							{t('features.plantSpecies.list.filters.allCategories')}
+						</SelectItem>
+						{Object.values(PlantSpeciesCategory).map((cat) => (
+							<SelectItem key={cat} value={cat}>
+								{PLANT_SPECIES_CATEGORIES[cat].icon}{' '}
+								{PLANT_SPECIES_CATEGORIES[cat].label}
+							</SelectItem>
+						))}
+					</SelectContent>
+				</Select>
+
+				{/* Difficulty filter */}
+				<Select
+					value={filters.difficulty ?? 'all'}
+					onValueChange={(v) =>
+						handleFilterChange(
+							'difficulty',
+							v === 'all' ? undefined : (v as PlantSpeciesDifficulty),
+						)
+					}
+				>
+					<SelectTrigger className="w-40">
+						<SelectValue
+							placeholder={t(
+								'features.plantSpecies.list.filters.allDifficulties',
+							)}
+						/>
+					</SelectTrigger>
+					<SelectContent>
+						<SelectItem value="all">
+							{t('features.plantSpecies.list.filters.allDifficulties')}
+						</SelectItem>
+						{Object.values(PlantSpeciesDifficulty).map((diff) => (
+							<SelectItem key={diff} value={diff}>
+								{PLANT_SPECIES_DIFFICULTY[diff].icon}{' '}
+								{PLANT_SPECIES_DIFFICULTY[diff].label}
+							</SelectItem>
+						))}
+					</SelectContent>
+				</Select>
+
+				{/* Verified Only toggle */}
+				<div className="flex items-center gap-2">
+					<Checkbox
+						id="verified-only"
+						checked={filters.verifiedOnly}
+						onCheckedChange={(checked) =>
+							handleFilterChange('verifiedOnly', Boolean(checked))
+						}
+					/>
+					<label htmlFor="verified-only" className="text-sm cursor-pointer whitespace-nowrap">
+						{t('features.plantSpecies.list.filters.verifiedOnly')}
+					</label>
+				</div>
+
+				{/* View mode toggle */}
+				<div className="ml-auto flex gap-1">
+					<Button
+						variant={viewMode === 'grid' ? 'default' : 'outline'}
+						size="icon"
+						onClick={() => setViewMode('grid')}
+						title="Grid view"
+					>
+						<LayoutGridIcon className="h-4 w-4" />
+					</Button>
+					<Button
+						variant={viewMode === 'table' ? 'default' : 'outline'}
+						size="icon"
+						onClick={() => setViewMode('table')}
+						title="Table view"
+					>
+						<ListIcon className="h-4 w-4" />
+					</Button>
+				</div>
+			</div>
+
+			{/* Content */}
+			{species.length === 0 ? (
+				/* Empty state */
+				<div className="flex flex-col items-center justify-center min-h-[300px] text-center space-y-3 py-12">
+					<div className="text-5xl">🌱</div>
+					<h3 className="text-lg font-semibold">
+						{t('features.plantSpecies.list.empty')}
+					</h3>
+					<p className="text-sm text-muted-foreground max-w-xs">
+						{t('features.plantSpecies.list.emptyDescription')}
+					</p>
+					{hasActiveFilters && (
+						<Button variant="outline" onClick={handleClearFilters}>
+							{t('features.plantSpecies.list.filters.clearFilters')}
+						</Button>
+					)}
+				</div>
+			) : viewMode === 'grid' ? (
+				/* Grid View */
+				<div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
+					{species.map((ps) => (
+						<PlantSpeciesCard
+							key={ps.id}
+							plantSpecies={ps}
+							onView={handleViewClick}
+							onEdit={handleEditClick}
+							onDelete={handleDeleteClick}
+						/>
+					))}
+				</div>
+			) : (
+				/* Table View */
+				<PlantSpeciesTable
+					plantSpecies={species}
+					onView={handleViewClick}
+					onEdit={handleEditClick}
+					onDelete={handleDeleteClick}
+				/>
+			)}
+
+			{/* Create Modal */}
+			<PlantSpeciesCreateModal
+				open={createDialogOpen}
+				onOpenChange={setCreateDialogOpen}
+				onSubmit={handleCreateSubmit}
+				isLoading={isCreating}
+				error={createError}
+			/>
+
+			{/* Update Form */}
+			<PlantSpeciesUpdateForm
+				plantSpecies={selectedSpecies}
+				open={updateDialogOpen}
+				onOpenChange={setUpdateDialogOpen}
+				onSubmit={handleUpdateSubmit}
+				isLoading={isUpdating}
+				error={updateError}
+			/>
+
+			{/* Delete Modal */}
+			<PlantSpeciesDeleteModal
+				plantSpecies={selectedDeleteSpecies}
+				open={deleteDialogOpen}
+				onOpenChange={setDeleteDialogOpen}
+				onConfirm={handleDeleteConfirm}
+				isLoading={isDeleting}
+			/>
+		</div>
+	);
+}

--- a/apps/web/features/plant-species/hooks/pages/usePlantSpeciesDetailPage.ts
+++ b/apps/web/features/plant-species/hooks/pages/usePlantSpeciesDetailPage.ts
@@ -26,9 +26,8 @@ export function usePlantSpeciesDetailPage(id: string) {
 		isLoading: isDeleting,
 	} = usePlantSpeciesDelete();
 
-	const [activeTab, setActiveTab] = useState<'overview' | 'care' | 'growth'>(
-		'overview',
-	);
+	const [updateDialogOpen, setUpdateDialogOpen] = useState(false);
+	const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
 
 	const handleUpdateSpecies = useCallback(
 		async (data: Omit<PlantSpeciesUpdateInput, 'id'>) => {
@@ -36,6 +35,7 @@ export function usePlantSpeciesDetailPage(id: string) {
 				{ id, ...data },
 				() => {
 					toast.success('Species updated successfully');
+					setUpdateDialogOpen(false);
 				},
 				() => {
 					toast.error('Failed to update species');
@@ -62,8 +62,10 @@ export function usePlantSpeciesDetailPage(id: string) {
 		plantSpecies,
 		isLoading,
 		error,
-		activeTab,
-		setActiveTab,
+		updateDialogOpen,
+		setUpdateDialogOpen,
+		deleteDialogOpen,
+		setDeleteDialogOpen,
 		handleUpdate: handleUpdateSpecies,
 		handleDelete: handleDeleteSpecies,
 		isUpdating,

--- a/apps/web/features/plant-species/locales/en.json
+++ b/apps/web/features/plant-species/locales/en.json
@@ -1,4 +1,6 @@
 {
+  "verified": "Verified",
+  "noEnvironmentalData": "No environmental data available",
   "categories": {
     "VEGETABLE": { "label": "Vegetable" },
     "FRUIT": { "label": "Fruit" },
@@ -77,6 +79,86 @@
     "CHALKY": {
       "label": "Chalky",
       "description": "Alkaline, free-draining"
+    }
+  },
+  "tabs": {
+    "care": "Care",
+    "growth": "Growth",
+    "environment": "Environment"
+  },
+  "sections": {
+    "careOverview": "Care Overview",
+    "growthInfo": "Growth Information",
+    "environmentalConditions": "Environmental Conditions"
+  },
+  "list": {
+    "title": "Species Library",
+    "description": "Browse and manage plant species in your library.",
+    "searchPlaceholder": "Search species...",
+    "empty": "No species found",
+    "emptyDescription": "Start building your species library by adding your first plant species.",
+    "filters": {
+      "allCategories": "All Categories",
+      "allDifficulties": "All Difficulties",
+      "verifiedOnly": "Verified Only",
+      "clearFilters": "Clear Filters"
+    },
+    "table": {
+      "columns": {
+        "image": "Image",
+        "name": "Name",
+        "category": "Category",
+        "difficulty": "Difficulty",
+        "status": "Status",
+        "actions": "Actions"
+      }
+    },
+    "actions": {
+      "view": "View",
+      "edit": "Edit",
+      "create": {
+        "button": "Add Species",
+        "title": "Add Species",
+        "description": "Add a new plant species to the library",
+        "submit": "Create",
+        "loading": "Creating...",
+        "success": "Species created successfully",
+        "error": "Failed to create species"
+      },
+      "update": {
+        "title": "Update Species",
+        "description": "Update plant species information",
+        "submit": "Update",
+        "loading": "Updating...",
+        "success": "Species updated successfully",
+        "error": "Failed to update species"
+      },
+      "delete": {
+        "label": "Delete",
+        "loading": "Deleting...",
+        "success": "Species deleted successfully",
+        "error": "Failed to delete species",
+        "confirm": {
+          "title": "Delete Species",
+          "description": "Are you sure you want to delete {name}? This action cannot be undone."
+        }
+      }
+    },
+    "error": {
+      "loading": "Error loading species: {message}"
+    }
+  },
+  "detail": {
+    "breadcrumbs": {
+      "speciesLibrary": "Species Library"
+    },
+    "notFound": "Species not found",
+    "actions": {
+      "edit": "Edit",
+      "delete": "Delete"
+    },
+    "error": {
+      "loading": "Error loading species: {message}"
     }
   }
 }

--- a/apps/web/features/plant-species/locales/es.json
+++ b/apps/web/features/plant-species/locales/es.json
@@ -1,4 +1,6 @@
 {
+  "verified": "Verificado",
+  "noEnvironmentalData": "No hay datos ambientales disponibles",
   "categories": {
     "VEGETABLE": { "label": "Verdura" },
     "FRUIT": { "label": "Fruta" },
@@ -77,6 +79,86 @@
     "CHALKY": {
       "label": "Calcáreo",
       "description": "Alcalino, buen drenaje"
+    }
+  },
+  "tabs": {
+    "care": "Cuidados",
+    "growth": "Crecimiento",
+    "environment": "Entorno"
+  },
+  "sections": {
+    "careOverview": "Resumen de Cuidados",
+    "growthInfo": "Información de Crecimiento",
+    "environmentalConditions": "Condiciones Ambientales"
+  },
+  "list": {
+    "title": "Biblioteca de Especies",
+    "description": "Navega y gestiona las especies de plantas en tu biblioteca.",
+    "searchPlaceholder": "Buscar especies...",
+    "empty": "No se encontraron especies",
+    "emptyDescription": "Empieza a construir tu biblioteca de especies añadiendo tu primera especie de planta.",
+    "filters": {
+      "allCategories": "Todas las Categorías",
+      "allDifficulties": "Todas las Dificultades",
+      "verifiedOnly": "Solo Verificadas",
+      "clearFilters": "Limpiar Filtros"
+    },
+    "table": {
+      "columns": {
+        "image": "Imagen",
+        "name": "Nombre",
+        "category": "Categoría",
+        "difficulty": "Dificultad",
+        "status": "Estado",
+        "actions": "Acciones"
+      }
+    },
+    "actions": {
+      "view": "Ver",
+      "edit": "Editar",
+      "create": {
+        "button": "Añadir Especie",
+        "title": "Añadir Especie",
+        "description": "Añade una nueva especie de planta a la biblioteca",
+        "submit": "Crear",
+        "loading": "Creando...",
+        "success": "Especie creada correctamente",
+        "error": "Error al crear la especie"
+      },
+      "update": {
+        "title": "Actualizar Especie",
+        "description": "Actualiza la información de la especie de planta",
+        "submit": "Actualizar",
+        "loading": "Actualizando...",
+        "success": "Especie actualizada correctamente",
+        "error": "Error al actualizar la especie"
+      },
+      "delete": {
+        "label": "Eliminar",
+        "loading": "Eliminando...",
+        "success": "Especie eliminada correctamente",
+        "error": "Error al eliminar la especie",
+        "confirm": {
+          "title": "Eliminar Especie",
+          "description": "¿Estás seguro de que quieres eliminar {name}? Esta acción no se puede deshacer."
+        }
+      }
+    },
+    "error": {
+      "loading": "Error al cargar las especies: {message}"
+    }
+  },
+  "detail": {
+    "breadcrumbs": {
+      "speciesLibrary": "Biblioteca de Especies"
+    },
+    "notFound": "Especie no encontrada",
+    "actions": {
+      "edit": "Editar",
+      "delete": "Eliminar"
+    },
+    "error": {
+      "loading": "Error al cargar la especie: {message}"
     }
   }
 }

--- a/apps/web/shared/hooks/use-routes.ts
+++ b/apps/web/shared/hooks/use-routes.ts
@@ -1,5 +1,5 @@
 import { SidebarData } from '@/shared/interfaces/sidebar-data.interface';
-import { Home, LayoutGrid, MapPin, Settings, Sprout } from 'lucide-react';
+import { BookOpen, Home, LayoutGrid, MapPin, Settings, Sprout } from 'lucide-react';
 import { useLocale, useTranslations } from 'next-intl';
 import { usePathname } from 'next/navigation';
 
@@ -24,6 +24,7 @@ export const useAppRoutes = () => {
 		plants: buildLocalizedUrl('/plants'),
 		growingUnits: buildLocalizedUrl('/growing-units'),
 		locations: buildLocalizedUrl('/locations'),
+		plantSpecies: buildLocalizedUrl('/plant-species'),
 	} as const;
 
 	/**
@@ -59,6 +60,12 @@ export const useAppRoutes = () => {
 							url: routes.growingUnits,
 							isActive: pathname === routes.growingUnits,
 							icon: LayoutGrid,
+						},
+						{
+							title: t('plantSpecies'),
+							url: routes.plantSpecies,
+							isActive: pathname?.startsWith(routes.plantSpecies) ?? false,
+							icon: BookOpen,
 						},
 					],
 				},

--- a/apps/web/shared/locales/en.json
+++ b/apps/web/shared/locales/en.json
@@ -28,7 +28,8 @@
     "completed": "Completed",
     "pending": "Pending",
     "viewAll": "View all",
-    "seeAll": "See all"
+    "seeAll": "See all",
+    "add": "Add"
   },
   "nav": {
     "home": "Home",
@@ -36,6 +37,7 @@
     "plants": "Plants",
     "growingUnits": "Growing Units",
     "locations": "Locations",
+    "plantSpecies": "Species Library",
     "search": "Search",
     "searchPlaceholder": "Search..."
   },

--- a/apps/web/shared/locales/es.json
+++ b/apps/web/shared/locales/es.json
@@ -28,7 +28,8 @@
     "completed": "Completado",
     "pending": "Pendiente",
     "viewAll": "Ver todo",
-    "seeAll": "Ver todas"
+    "seeAll": "Ver todas",
+    "add": "Añadir"
   },
   "nav": {
     "home": "Inicio",
@@ -36,6 +37,7 @@
     "plants": "Plantas",
     "growingUnits": "Unidades de Cultivo",
     "locations": "Ubicaciones",
+    "plantSpecies": "Biblioteca de Especies",
     "search": "Buscar",
     "searchPlaceholder": "Buscar..."
   },


### PR DESCRIPTION
Implements #172

## Changes

- `PlantSpeciesListPage` with grid/table toggle, filters, CRUD dialogs, loading/empty/error states
- `PlantSpeciesDetailPage` with breadcrumbs, detail card, edit/delete actions
- Next.js routes for `/plant-species` and `/plant-species/[id]`
- Plant Species sidebar navigation entry
- Complete translation keys for en/es locales

Generated with [Claude Code](https://claude.ai/code)