### PR TITLE
fix(api): Add error handling to all event handlers

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "api",
-	"version": "1.8.0",
+	"version": "1.9.0",
 	"description": "",
 	"author": "",
 	"private": true,

--- a/apps/api/src/core/location-context/application/event-handlers/location/location-created/location-created.event-handler.spec.ts
+++ b/apps/api/src/core/location-context/application/event-handlers/location/location-created/location-created.event-handler.spec.ts
@@ -120,6 +120,33 @@ describe('LocationCreatedEventHandler', () => {
 			);
 			expect(mockLocationReadRepository.save).toHaveBeenCalledTimes(1);
 		});
+
+		it('should not throw when an error occurs', async () => {
+			const locationId = '123e4567-e89b-12d3-a456-426614174000';
+			const event = new LocationCreatedEvent(
+				{
+					aggregateRootId: locationId,
+					aggregateRootType: 'LocationAggregate',
+					entityId: locationId,
+					entityType: 'LocationAggregate',
+					eventType: 'LocationCreatedEvent',
+				},
+				{
+					id: locationId,
+					name: 'Living Room',
+					type: LocationTypeEnum.ROOM,
+					description: 'North-facing room with good sunlight',
+					parentLocationId: null,
+				},
+			);
+
+			mockAssertLocationExistsService.execute.mockRejectedValue(
+				new Error('Database error'),
+			);
+
+			await expect(handler.handle(event)).resolves.not.toThrow();
+			expect(mockLocationReadRepository.save).not.toHaveBeenCalled();
+		});
 	});
 });
 

--- a/apps/api/src/core/location-context/application/event-handlers/location/location-created/location-created.event-handler.ts
+++ b/apps/api/src/core/location-context/application/event-handlers/location/location-created/location-created.event-handler.ts
@@ -36,22 +36,29 @@ export class LocationCreatedEventHandler
 	 * @param event - The LocationCreatedEvent event to handle
 	 */
 	async handle(event: LocationCreatedEvent) {
-		this.logger.log(`Handling location created event: ${event.entityId}`);
+		try {
+			this.logger.log(`Handling location created event: ${event.entityId}`);
 
-		this.logger.debug(
-			`Location created event data: ${JSON.stringify(event.data)}`,
-		);
+			this.logger.debug(
+				`Location created event data: ${JSON.stringify(event.data)}`,
+			);
 
-		// 01: Get the location aggregate to have the complete state
-		const locationAggregate = await this.assertLocationExistsService.execute(
-			event.entityId,
-		);
+			// 01: Get the location aggregate to have the complete state
+			const locationAggregate = await this.assertLocationExistsService.execute(
+				event.entityId,
+			);
 
-		// 02: Create the location view model from the aggregate
-		const locationViewModel: LocationViewModel =
-			this.locationViewModelFactory.fromAggregate(locationAggregate);
+			// 02: Create the location view model from the aggregate
+			const locationViewModel: LocationViewModel =
+				this.locationViewModelFactory.fromAggregate(locationAggregate);
 
-		// 03: Save the location view model
-		await this.locationReadRepository.save(locationViewModel);
+			// 03: Save the location view model
+			await this.locationReadRepository.save(locationViewModel);
+		} catch (error) {
+			this.logger.error(
+				`Failed to handle location created event: ${event.entityId}`,
+				error,
+			);
+		}
 	}
 }

--- a/apps/api/src/core/location-context/application/event-handlers/location/location-deleted/location-deleted.event-handler.spec.ts
+++ b/apps/api/src/core/location-context/application/event-handlers/location/location-deleted/location-deleted.event-handler.spec.ts
@@ -68,6 +68,32 @@ describe('LocationDeletedEventHandler', () => {
 			);
 			expect(mockLocationReadRepository.delete).toHaveBeenCalledTimes(1);
 		});
+
+		it('should not throw when an error occurs', async () => {
+			const locationId = '123e4567-e89b-12d3-a456-426614174000';
+			const event = new LocationDeletedEvent(
+				{
+					aggregateRootId: locationId,
+					aggregateRootType: 'LocationAggregate',
+					entityId: locationId,
+					entityType: 'LocationAggregate',
+					eventType: 'LocationDeletedEvent',
+				},
+				{
+					id: locationId,
+					name: 'Living Room',
+					type: LocationTypeEnum.ROOM,
+					description: 'North-facing room with good sunlight',
+					parentLocationId: null,
+				},
+			);
+
+			mockLocationReadRepository.delete.mockRejectedValue(
+				new Error('Database error'),
+			);
+
+			await expect(handler.handle(event)).resolves.not.toThrow();
+		});
 	});
 });
 

--- a/apps/api/src/core/location-context/application/event-handlers/location/location-deleted/location-deleted.event-handler.ts
+++ b/apps/api/src/core/location-context/application/event-handlers/location/location-deleted/location-deleted.event-handler.ts
@@ -31,14 +31,21 @@ export class LocationDeletedEventHandler
 	 * @param event - The LocationDeletedEvent event to handle
 	 */
 	async handle(event: LocationDeletedEvent) {
-		this.logger.log(`Handling location deleted event: ${event.entityId}`);
+		try {
+			this.logger.log(`Handling location deleted event: ${event.entityId}`);
 
-		this.logger.debug(
-			`Location deleted event data: ${JSON.stringify(event.data)}`,
-		);
+			this.logger.debug(
+				`Location deleted event data: ${JSON.stringify(event.data)}`,
+			);
 
-		// 01: Delete the location view model
-		await this.locationReadRepository.delete(event.entityId);
+			// 01: Delete the location view model
+			await this.locationReadRepository.delete(event.entityId);
+		} catch (error) {
+			this.logger.error(
+				`Failed to handle location deleted event: ${event.entityId}`,
+				error,
+			);
+		}
 	}
 }
 

--- a/apps/api/src/core/location-context/application/event-handlers/location/location-updated/location-updated.event-handler.spec.ts
+++ b/apps/api/src/core/location-context/application/event-handlers/location/location-updated/location-updated.event-handler.spec.ts
@@ -120,6 +120,33 @@ describe('LocationUpdatedEventHandler', () => {
 			);
 			expect(mockLocationReadRepository.save).toHaveBeenCalledTimes(1);
 		});
+
+		it('should not throw when an error occurs', async () => {
+			const locationId = '123e4567-e89b-12d3-a456-426614174000';
+			const event = new LocationUpdatedEvent(
+				{
+					aggregateRootId: locationId,
+					aggregateRootType: 'LocationAggregate',
+					entityId: locationId,
+					entityType: 'LocationAggregate',
+					eventType: 'LocationUpdatedEvent',
+				},
+				{
+					id: locationId,
+					name: 'Living Room Updated',
+					type: LocationTypeEnum.ROOM,
+					description: 'Updated description',
+					parentLocationId: null,
+				},
+			);
+
+			mockAssertLocationExistsService.execute.mockRejectedValue(
+				new Error('Database error'),
+			);
+
+			await expect(handler.handle(event)).resolves.not.toThrow();
+			expect(mockLocationReadRepository.save).not.toHaveBeenCalled();
+		});
 	});
 });
 

--- a/apps/api/src/core/location-context/application/event-handlers/location/location-updated/location-updated.event-handler.ts
+++ b/apps/api/src/core/location-context/application/event-handlers/location/location-updated/location-updated.event-handler.ts
@@ -35,22 +35,29 @@ export class LocationUpdatedEventHandler
 	 * @param event - The LocationUpdatedEvent event to handle
 	 */
 	async handle(event: LocationUpdatedEvent) {
-		this.logger.log(`Handling location updated event: ${event.entityId}`);
+		try {
+			this.logger.log(`Handling location updated event: ${event.entityId}`);
 
-		this.logger.debug(
-			`Location updated event data: ${JSON.stringify(event.data)}`,
-		);
+			this.logger.debug(
+				`Location updated event data: ${JSON.stringify(event.data)}`,
+			);
 
-		// 01: Get the location aggregate to have the complete state
-		const locationAggregate = await this.assertLocationExistsService.execute(
-			event.entityId,
-		);
+			// 01: Get the location aggregate to have the complete state
+			const locationAggregate = await this.assertLocationExistsService.execute(
+				event.entityId,
+			);
 
-		// 02: Create the location view model from the aggregate
-		const locationViewModel: LocationViewModel =
-			this.locationViewModelFactory.fromAggregate(locationAggregate);
+			// 02: Create the location view model from the aggregate
+			const locationViewModel: LocationViewModel =
+				this.locationViewModelFactory.fromAggregate(locationAggregate);
 
-		// 03: Save the updated location view model
-		await this.locationReadRepository.save(locationViewModel);
+			// 03: Save the updated location view model
+			await this.locationReadRepository.save(locationViewModel);
+		} catch (error) {
+			this.logger.error(
+				`Failed to handle location updated event: ${event.entityId}`,
+				error,
+			);
+		}
 	}
 }

--- a/apps/api/src/core/plant-context/application/event-handlers/growing-unit/growing-unit-created/growing-unit-created.event-handler.spec.ts
+++ b/apps/api/src/core/plant-context/application/event-handlers/growing-unit/growing-unit-created/growing-unit-created.event-handler.spec.ts
@@ -167,5 +167,35 @@ describe('GrowingUnitCreatedEventHandler', () => {
 			);
 			expect(mockGrowingUnitReadRepository.save).toHaveBeenCalledTimes(1);
 		});
+
+		it('should not throw when an error occurs', async () => {
+			const growingUnitId = '123e4567-e89b-12d3-a456-426614174000';
+			const locationId = '323e4567-e89b-12d3-a456-426614174000';
+			const event = new GrowingUnitCreatedEvent(
+				{
+					aggregateRootId: growingUnitId,
+					aggregateRootType: 'GrowingUnitAggregate',
+					entityId: growingUnitId,
+					entityType: 'GrowingUnitAggregate',
+					eventType: 'GrowingUnitCreatedEvent',
+				},
+				{
+					id: growingUnitId,
+					locationId,
+					name: 'Garden Bed 1',
+					type: GrowingUnitTypeEnum.GARDEN_BED,
+					capacity: 10,
+					dimensions: null,
+					plants: [],
+				},
+			);
+
+			mockAssertGrowingUnitExistsService.execute.mockRejectedValue(
+				new Error('Database error'),
+			);
+
+			await expect(handler.handle(event)).resolves.not.toThrow();
+			expect(mockGrowingUnitReadRepository.save).not.toHaveBeenCalled();
+		});
 	});
 });

--- a/apps/api/src/core/plant-context/application/event-handlers/growing-unit/growing-unit-created/growing-unit-created.event-handler.ts
+++ b/apps/api/src/core/plant-context/application/event-handlers/growing-unit/growing-unit-created/growing-unit-created.event-handler.ts
@@ -37,31 +37,38 @@ export class GrowingUnitCreatedEventHandler
 	 * @param event - The GrowingUnitCreatedEvent event to handle
 	 */
 	async handle(event: GrowingUnitCreatedEvent) {
-		this.logger.log(`Handling growing unit created event: ${event.entityId}`);
+		try {
+			this.logger.log(`Handling growing unit created event: ${event.entityId}`);
 
-		this.logger.debug(
-			`Growing unit created event data: ${JSON.stringify(event.data)}`,
-		);
+			this.logger.debug(
+				`Growing unit created event data: ${JSON.stringify(event.data)}`,
+			);
 
-		// 01: Get the growing unit aggregate to have the complete state
-		const growingUnitAggregate =
-			await this.assertGrowingUnitExistsService.execute(event.entityId);
+			// 01: Get the growing unit aggregate to have the complete state
+			const growingUnitAggregate =
+				await this.assertGrowingUnitExistsService.execute(event.entityId);
 
-		const locationViewModel = await this.queryBus.execute(
-			new LocationViewModelFindByIdQuery({
-				id: growingUnitAggregate.locationId.value,
-			}),
-		);
+			const locationViewModel = await this.queryBus.execute(
+				new LocationViewModelFindByIdQuery({
+					id: growingUnitAggregate.locationId.value,
+				}),
+			);
 
-		// 02: Create the growing unit view model from the aggregate
-		const growingUnitViewModel: GrowingUnitViewModel =
-			this.growingUnitViewModelBuilder
-				.reset()
-				.fromAggregate(growingUnitAggregate)
-				.withLocation(locationViewModel)
-				.build();
+			// 02: Create the growing unit view model from the aggregate
+			const growingUnitViewModel: GrowingUnitViewModel =
+				this.growingUnitViewModelBuilder
+					.reset()
+					.fromAggregate(growingUnitAggregate)
+					.withLocation(locationViewModel)
+					.build();
 
-		// 03: Save the growing unit view model
-		await this.growingUnitReadRepository.save(growingUnitViewModel);
+			// 03: Save the growing unit view model
+			await this.growingUnitReadRepository.save(growingUnitViewModel);
+		} catch (error) {
+			this.logger.error(
+				`Failed to handle growing unit created event: ${event.entityId}`,
+				error,
+			);
+		}
 	}
 }

--- a/apps/api/src/core/plant-context/application/event-handlers/growing-unit/growing-unit-deleted/growing-unit-deleted.event-handler.spec.ts
+++ b/apps/api/src/core/plant-context/application/event-handlers/growing-unit/growing-unit-deleted/growing-unit-deleted.event-handler.spec.ts
@@ -70,5 +70,34 @@ describe('GrowingUnitDeletedEventHandler', () => {
 			);
 			expect(mockGrowingUnitReadRepository.delete).toHaveBeenCalledTimes(1);
 		});
+
+		it('should not throw when an error occurs', async () => {
+			const growingUnitId = '123e4567-e89b-12d3-a456-426614174000';
+			const locationId = '323e4567-e89b-12d3-a456-426614174000';
+			const event = new GrowingUnitDeletedEvent(
+				{
+					aggregateRootId: growingUnitId,
+					aggregateRootType: 'GrowingUnitAggregate',
+					entityId: growingUnitId,
+					entityType: 'GrowingUnitAggregate',
+					eventType: 'GrowingUnitDeletedEvent',
+				},
+				{
+					id: growingUnitId,
+					locationId,
+					name: 'Garden Bed 1',
+					type: 'GARDEN_BED',
+					capacity: 10,
+					dimensions: null,
+					plants: [],
+				},
+			);
+
+			mockGrowingUnitReadRepository.delete.mockRejectedValue(
+				new Error('Database error'),
+			);
+
+			await expect(handler.handle(event)).resolves.not.toThrow();
+		});
 	});
 });

--- a/apps/api/src/core/plant-context/application/event-handlers/growing-unit/growing-unit-deleted/growing-unit-deleted.event-handler.ts
+++ b/apps/api/src/core/plant-context/application/event-handlers/growing-unit/growing-unit-deleted/growing-unit-deleted.event-handler.ts
@@ -31,13 +31,20 @@ export class GrowingUnitDeletedEventHandler
 	 * @param event - The GrowingUnitDeletedEvent event to handle
 	 */
 	async handle(event: GrowingUnitDeletedEvent) {
-		this.logger.log(`Handling growing unit deleted event: ${event.entityId}`);
+		try {
+			this.logger.log(`Handling growing unit deleted event: ${event.entityId}`);
 
-		this.logger.debug(
-			`Growing unit deleted event data: ${JSON.stringify(event.data)}`,
-		);
+			this.logger.debug(
+				`Growing unit deleted event data: ${JSON.stringify(event.data)}`,
+			);
 
-		// 01: Delete the growing unit view model
-		await this.growingUnitReadRepository.delete(event.entityId);
+			// 01: Delete the growing unit view model
+			await this.growingUnitReadRepository.delete(event.entityId);
+		} catch (error) {
+			this.logger.error(
+				`Failed to handle growing unit deleted event: ${event.entityId}`,
+				error,
+			);
+		}
 	}
 }

--- a/apps/api/src/core/plant-context/application/event-handlers/growing-unit/growing-unit-plant-removed/growing-unit-removed.event-handler.spec.ts
+++ b/apps/api/src/core/plant-context/application/event-handlers/growing-unit/growing-unit-plant-removed/growing-unit-removed.event-handler.spec.ts
@@ -168,5 +168,37 @@ describe('GrowingUnitPlantRemovedEventHandler', () => {
 			expect(mockGrowingUnitReadRepository.save).toHaveBeenCalled();
 			expect(mockGrowingUnitReadRepository.save).toHaveBeenCalledTimes(1);
 		});
+
+		it('should not throw when an error occurs', async () => {
+			const growingUnitId = '123e4567-e89b-12d3-a456-426614174000';
+			const plantId = '223e4567-e89b-12d3-a456-426614174000';
+
+			const event = new GrowingUnitPlantRemovedEvent(
+				{
+					aggregateRootId: growingUnitId,
+					aggregateRootType: GrowingUnitAggregate.name,
+					entityId: plantId,
+					entityType: PlantEntity.name,
+					eventType: GrowingUnitPlantRemovedEvent.name,
+				},
+				{
+					plant: {
+						id: plantId,
+						name: 'Basil',
+						species: 'Ocimum basilicum',
+						plantedDate: null,
+						notes: null,
+						status: 'PLANTED',
+					},
+				},
+			);
+
+			mockAssertGrowingUnitExistsService.execute.mockRejectedValue(
+				new Error('Database error'),
+			);
+
+			await expect(handler.handle(event)).resolves.not.toThrow();
+			expect(mockGrowingUnitReadRepository.save).not.toHaveBeenCalled();
+		});
 	});
 });

--- a/apps/api/src/core/plant-context/application/event-handlers/growing-unit/growing-unit-updated/growing-unit-updated.event-handler.spec.ts
+++ b/apps/api/src/core/plant-context/application/event-handlers/growing-unit/growing-unit-updated/growing-unit-updated.event-handler.spec.ts
@@ -167,5 +167,35 @@ describe('GrowingUnitUpdatedEventHandler', () => {
 			);
 			expect(mockGrowingUnitReadRepository.save).toHaveBeenCalledTimes(1);
 		});
+
+		it('should not throw when an error occurs', async () => {
+			const growingUnitId = '123e4567-e89b-12d3-a456-426614174000';
+			const locationId = '323e4567-e89b-12d3-a456-426614174000';
+			const event = new GrowingUnitUpdatedEvent(
+				{
+					aggregateRootId: growingUnitId,
+					aggregateRootType: 'GrowingUnitAggregate',
+					entityId: growingUnitId,
+					entityType: 'GrowingUnitAggregate',
+					eventType: 'GrowingUnitUpdatedEvent',
+				},
+				{
+					id: growingUnitId,
+					locationId,
+					name: 'Garden Bed 1 Updated',
+					type: GrowingUnitTypeEnum.GARDEN_BED,
+					capacity: 15,
+					dimensions: null,
+					plants: [],
+				},
+			);
+
+			mockAssertGrowingUnitExistsService.execute.mockRejectedValue(
+				new Error('Database error'),
+			);
+
+			await expect(handler.handle(event)).resolves.not.toThrow();
+			expect(mockGrowingUnitReadRepository.save).not.toHaveBeenCalled();
+		});
 	});
 });

--- a/apps/api/src/core/plant-context/application/event-handlers/growing-unit/growing-unit-updated/growing-unit-updated.event-handler.ts
+++ b/apps/api/src/core/plant-context/application/event-handlers/growing-unit/growing-unit-updated/growing-unit-updated.event-handler.ts
@@ -37,31 +37,38 @@ export class GrowingUnitUpdatedEventHandler
 	 * @param event - The GrowingUnitUpdatedEvent event to handle
 	 */
 	async handle(event: GrowingUnitUpdatedEvent) {
-		this.logger.log(`Handling growing unit updated event: ${event.entityId}`);
+		try {
+			this.logger.log(`Handling growing unit updated event: ${event.entityId}`);
 
-		this.logger.debug(
-			`Growing unit updated event data: ${JSON.stringify(event.data)}`,
-		);
+			this.logger.debug(
+				`Growing unit updated event data: ${JSON.stringify(event.data)}`,
+			);
 
-		// 01: Get the growing unit aggregate to have the complete state
-		const growingUnitAggregate =
-			await this.assertGrowingUnitExistsService.execute(event.entityId);
+			// 01: Get the growing unit aggregate to have the complete state
+			const growingUnitAggregate =
+				await this.assertGrowingUnitExistsService.execute(event.entityId);
 
-		const locationViewModel = await this.queryBus.execute(
-			new LocationViewModelFindByIdQuery({
-				id: growingUnitAggregate.locationId.value,
-			}),
-		);
+			const locationViewModel = await this.queryBus.execute(
+				new LocationViewModelFindByIdQuery({
+					id: growingUnitAggregate.locationId.value,
+				}),
+			);
 
-		// 02: Update the growing unit view model from the aggregate
-		const growingUnitViewModel: GrowingUnitViewModel =
-			this.growingUnitViewModelBuilder
-				.reset()
-				.fromAggregate(growingUnitAggregate)
-				.withLocation(locationViewModel)
-				.build();
+			// 02: Update the growing unit view model from the aggregate
+			const growingUnitViewModel: GrowingUnitViewModel =
+				this.growingUnitViewModelBuilder
+					.reset()
+					.fromAggregate(growingUnitAggregate)
+					.withLocation(locationViewModel)
+					.build();
 
-		// 03: Save the updated growing unit view model
-		await this.growingUnitReadRepository.save(growingUnitViewModel);
+			// 03: Save the updated growing unit view model
+			await this.growingUnitReadRepository.save(growingUnitViewModel);
+		} catch (error) {
+			this.logger.error(
+				`Failed to handle growing unit updated event: ${event.entityId}`,
+				error,
+			);
+		}
 	}
 }

--- a/apps/api/src/core/plant-context/application/event-handlers/plant/plant-created/plant-created.event-handler.spec.ts
+++ b/apps/api/src/core/plant-context/application/event-handlers/plant/plant-created/plant-created.event-handler.spec.ts
@@ -1,55 +1,41 @@
 import { Test } from '@nestjs/testing';
 import { QueryBus } from '@nestjs/cqrs';
 
-import { GrowingUnitPlantAddedEventHandler } from '@/core/plant-context/application/event-handlers/growing-unit/growing-unit-plant-added/growing-unit-added.event-handler';
-import { GrowingUnitPlantAddedEvent } from '@/core/plant-context/domain/events/growing-unit/growing-unit/growing-unit-plant-added/growing-unit-plant-added.event';
+import { PlantCreatedEventHandler } from '@/core/plant-context/application/event-handlers/plant/plant-created/plant-created.event-handler';
+import { PlantCreatedEvent } from '@/core/plant-context/application/events/plant/plant-created/plant-created.event';
 import { AssertGrowingUnitExistsService } from '@/core/plant-context/application/services/growing-unit/assert-growing-unit-exists/assert-growing-unit-exists.service';
 import { AssertPlantExistsInGrowingUnitService } from '@/core/plant-context/application/services/growing-unit/assert-plant-exists-in-growing-unit/assert-plant-exists-in-growing-unit.service';
 import { GrowingUnitAggregate } from '@/core/plant-context/domain/aggregates/growing-unit/growing-unit.aggregate';
 import { PlantEntity } from '@/core/plant-context/domain/entities/plant/plant.entity';
 import { GrowingUnitTypeEnum } from '@/core/plant-context/domain/enums/growing-unit/growing-unit-type/growing-unit-type.enum';
 import { PlantStatusEnum } from '@/core/plant-context/domain/enums/plant/plant-status/plant-status.enum';
-import { LocationViewModel } from '@/core/plant-context/domain/view-models/location/location.view-model';
-import { GrowingUnitViewModelBuilder } from '@/core/plant-context/domain/builders/growing-unit/growing-unit-view-model.builder';
 import { PlantViewModelBuilder } from '@/core/plant-context/domain/builders/plant/plant-view-model.builder';
 import {
-	GROWING_UNIT_READ_REPOSITORY_TOKEN,
-	IGrowingUnitReadRepository,
-} from '@/core/plant-context/domain/repositories/growing-unit/growing-unit-read/growing-unit-read.repository';
-import {
-	PLANT_READ_REPOSITORY_TOKEN,
 	IPlantReadRepository,
+	PLANT_READ_REPOSITORY_TOKEN,
 } from '@/core/plant-context/domain/repositories/plant/plant-read/plant-read.repository';
+import { LocationViewModel } from '@/core/plant-context/domain/view-models/location/location.view-model';
+import { PlantViewModel } from '@/core/plant-context/domain/view-models/plant/plant.view-model';
 import { GrowingUnitCapacityValueObject } from '@/core/plant-context/domain/value-objects/growing-unit/growing-unit-capacity/growing-unit-capacity.vo';
 import { GrowingUnitNameValueObject } from '@/core/plant-context/domain/value-objects/growing-unit/growing-unit-name/growing-unit-name.vo';
 import { GrowingUnitTypeValueObject } from '@/core/plant-context/domain/value-objects/growing-unit/growing-unit-type/growing-unit-type.vo';
 import { PlantNameValueObject } from '@/core/plant-context/domain/value-objects/plant/plant-name/plant-name.vo';
 import { PlantSpeciesValueObject } from '@/core/plant-context/domain/value-objects/plant/plant-species/plant-species.vo';
 import { PlantStatusValueObject } from '@/core/plant-context/domain/value-objects/plant/plant-status/plant-status.vo';
-import { GrowingUnitViewModel } from '@/core/plant-context/domain/view-models/growing-unit/growing-unit.view-model';
-import { PlantViewModel } from '@/core/plant-context/domain/view-models/plant/plant.view-model';
 import { GrowingUnitUuidValueObject } from '@/shared/domain/value-objects/identifiers/growing-unit-uuid/growing-unit-uuid.vo';
 import { LocationUuidValueObject } from '@/shared/domain/value-objects/identifiers/location-uuid/location-uuid.vo';
 import { PlantUuidValueObject } from '@/shared/domain/value-objects/identifiers/plant-uuid/plant-uuid.vo';
+import { LocationViewModelFindByIdQuery } from '@/core/location-context/application/queries/location/location-view-model-find-by-id/location-view-model-find-by-id.query';
 
-describe('GrowingUnitPlantAddedEventHandler', () => {
-	let handler: GrowingUnitPlantAddedEventHandler;
-	let mockGrowingUnitReadRepository: jest.Mocked<IGrowingUnitReadRepository>;
+describe('PlantCreatedEventHandler', () => {
+	let handler: PlantCreatedEventHandler;
 	let mockPlantReadRepository: jest.Mocked<IPlantReadRepository>;
 	let mockAssertGrowingUnitExistsService: jest.Mocked<AssertGrowingUnitExistsService>;
 	let mockAssertPlantExistsInGrowingUnitService: jest.Mocked<AssertPlantExistsInGrowingUnitService>;
-	let mockGrowingUnitViewModelBuilder: jest.Mocked<GrowingUnitViewModelBuilder>;
 	let mockPlantViewModelBuilder: jest.Mocked<PlantViewModelBuilder>;
 	let mockQueryBus: jest.Mocked<QueryBus>;
 
 	beforeEach(async () => {
-		mockGrowingUnitReadRepository = {
-			findById: jest.fn(),
-			findByCriteria: jest.fn(),
-			save: jest.fn(),
-			delete: jest.fn(),
-		} as unknown as jest.Mocked<IGrowingUnitReadRepository>;
-
 		mockPlantReadRepository = {
 			findById: jest.fn(),
 			findByCriteria: jest.fn(),
@@ -65,36 +51,10 @@ describe('GrowingUnitPlantAddedEventHandler', () => {
 			execute: jest.fn(),
 		} as unknown as jest.Mocked<AssertPlantExistsInGrowingUnitService>;
 
-		mockGrowingUnitViewModelBuilder = {
-			reset: jest.fn().mockReturnThis(),
-			fromAggregate: jest.fn().mockReturnThis(),
-			withId: jest.fn().mockReturnThis(),
-			withLocation: jest.fn().mockReturnThis(),
-			withName: jest.fn().mockReturnThis(),
-			withType: jest.fn().mockReturnThis(),
-			withCapacity: jest.fn().mockReturnThis(),
-			withDimensions: jest.fn().mockReturnThis(),
-			withPlants: jest.fn().mockReturnThis(),
-			withRemainingCapacity: jest.fn().mockReturnThis(),
-			withNumberOfPlants: jest.fn().mockReturnThis(),
-			withVolume: jest.fn().mockReturnThis(),
-			withCreatedAt: jest.fn().mockReturnThis(),
-			withUpdatedAt: jest.fn().mockReturnThis(),
-			build: jest.fn(),
-		} as unknown as jest.Mocked<GrowingUnitViewModelBuilder>;
-
 		mockPlantViewModelBuilder = {
 			reset: jest.fn().mockReturnThis(),
 			fromEntity: jest.fn().mockReturnThis(),
-			withId: jest.fn().mockReturnThis(),
 			withGrowingUnitId: jest.fn().mockReturnThis(),
-			withName: jest.fn().mockReturnThis(),
-			withSpecies: jest.fn().mockReturnThis(),
-			withPlantedDate: jest.fn().mockReturnThis(),
-			withNotes: jest.fn().mockReturnThis(),
-			withStatus: jest.fn().mockReturnThis(),
-			withCreatedAt: jest.fn().mockReturnThis(),
-			withUpdatedAt: jest.fn().mockReturnThis(),
 			withLocation: jest.fn().mockReturnThis(),
 			withGrowingUnit: jest.fn().mockReturnThis(),
 			build: jest.fn(),
@@ -106,11 +66,7 @@ describe('GrowingUnitPlantAddedEventHandler', () => {
 
 		const module = await Test.createTestingModule({
 			providers: [
-				GrowingUnitPlantAddedEventHandler,
-				{
-					provide: GROWING_UNIT_READ_REPOSITORY_TOKEN,
-					useValue: mockGrowingUnitReadRepository,
-				},
+				PlantCreatedEventHandler,
 				{
 					provide: PLANT_READ_REPOSITORY_TOKEN,
 					useValue: mockPlantReadRepository,
@@ -124,10 +80,6 @@ describe('GrowingUnitPlantAddedEventHandler', () => {
 					useValue: mockAssertPlantExistsInGrowingUnitService,
 				},
 				{
-					provide: GrowingUnitViewModelBuilder,
-					useValue: mockGrowingUnitViewModelBuilder,
-				},
-				{
 					provide: PlantViewModelBuilder,
 					useValue: mockPlantViewModelBuilder,
 				},
@@ -138,9 +90,7 @@ describe('GrowingUnitPlantAddedEventHandler', () => {
 			],
 		}).compile();
 
-		handler = module.get<GrowingUnitPlantAddedEventHandler>(
-			GrowingUnitPlantAddedEventHandler,
-		);
+		handler = module.get<PlantCreatedEventHandler>(PlantCreatedEventHandler);
 	});
 
 	afterEach(() => {
@@ -148,27 +98,26 @@ describe('GrowingUnitPlantAddedEventHandler', () => {
 	});
 
 	describe('handle', () => {
-		it('should update growing unit view model when plant is added', async () => {
+		it('should create and save plant view model when event is handled', async () => {
 			const growingUnitId = '123e4567-e89b-12d3-a456-426614174000';
 			const locationId = '323e4567-e89b-12d3-a456-426614174000';
 			const plantId = '223e4567-e89b-12d3-a456-426614174000';
-			const event = new GrowingUnitPlantAddedEvent(
+
+			const event = new PlantCreatedEvent(
 				{
 					aggregateRootId: growingUnitId,
-					aggregateRootType: GrowingUnitAggregate.name,
+					aggregateRootType: 'GrowingUnitAggregate',
 					entityId: plantId,
-					entityType: PlantEntity.name,
-					eventType: GrowingUnitPlantAddedEvent.name,
+					entityType: 'PlantEntity',
+					eventType: 'PlantCreatedEvent',
 				},
 				{
-					plant: {
-						id: plantId,
-						name: 'Basil',
-						species: 'Ocimum basilicum',
-						plantedDate: null,
-						notes: null,
-						status: PlantStatusEnum.PLANTED,
-					},
+					id: plantId,
+					name: 'Basil',
+					species: 'Ocimum basilicum',
+					plantedDate: null,
+					notes: null,
+					status: PlantStatusEnum.PLANTED,
 				},
 			);
 
@@ -182,6 +131,15 @@ describe('GrowingUnitPlantAddedEventHandler', () => {
 				plants: [],
 			});
 
+			const mockPlant = new PlantEntity({
+				id: new PlantUuidValueObject(plantId),
+				name: new PlantNameValueObject('Basil'),
+				species: new PlantSpeciesValueObject('Ocimum basilicum'),
+				plantedDate: null,
+				notes: null,
+				status: new PlantStatusValueObject(PlantStatusEnum.PLANTED),
+			});
+
 			const now = new Date();
 			const location = new LocationViewModel({
 				id: locationId,
@@ -192,83 +150,60 @@ describe('GrowingUnitPlantAddedEventHandler', () => {
 				updatedAt: now,
 			});
 
-			const mockViewModel = new GrowingUnitViewModel({
-				id: growingUnitId,
-				location,
-				name: 'Garden Bed 1',
-				type: GrowingUnitTypeEnum.GARDEN_BED,
-				capacity: 10,
-				dimensions: null,
-				plants: [],
-				numberOfPlants: 1,
-				remainingCapacity: 9,
-				volume: 0,
+			const mockViewModel = new PlantViewModel({
+				id: plantId,
+				growingUnitId: growingUnitId,
+				name: 'Basil',
+				species: 'Ocimum basilicum',
+				plantedDate: null,
+				notes: null,
+				status: PlantStatusEnum.PLANTED,
 				createdAt: now,
 				updatedAt: now,
 			});
 
-			const mockPlant = new PlantEntity({
-				id: new PlantUuidValueObject(plantId),
-				name: new PlantNameValueObject('Basil'),
-				species: new PlantSpeciesValueObject('Ocimum basilicum'),
-				plantedDate: null,
-				notes: null,
-				status: new PlantStatusValueObject(PlantStatusEnum.PLANTED),
-			});
-
-			mockAssertGrowingUnitExistsService.execute.mockResolvedValue(
-				mockGrowingUnit,
-			);
-			mockAssertPlantExistsInGrowingUnitService.execute.mockResolvedValue(
-				mockPlant,
-			);
+			mockAssertGrowingUnitExistsService.execute.mockResolvedValue(mockGrowingUnit);
+			mockAssertPlantExistsInGrowingUnitService.execute.mockResolvedValue(mockPlant);
 			mockQueryBus.execute.mockResolvedValue(location);
-			mockPlantViewModelBuilder.build.mockReturnValue(
-				new PlantViewModel({
-					id: plantId,
-					growingUnitId: growingUnitId,
-					name: 'Basil',
-					species: 'Ocimum basilicum',
-					plantedDate: null,
-					notes: null,
-					status: PlantStatusEnum.PLANTED,
-					createdAt: now,
-					updatedAt: now,
-				}),
-			);
-			mockGrowingUnitViewModelBuilder.build.mockReturnValue(mockViewModel);
+			mockPlantViewModelBuilder.build.mockReturnValue(mockViewModel);
 			mockPlantReadRepository.save.mockResolvedValue(undefined);
-			mockGrowingUnitReadRepository.save.mockResolvedValue(undefined);
 
 			await handler.handle(event);
 
-			expect(mockAssertGrowingUnitExistsService.execute).toHaveBeenCalledWith(
-				growingUnitId,
+			expect(mockAssertGrowingUnitExistsService.execute).toHaveBeenCalledWith(growingUnitId);
+			expect(mockAssertPlantExistsInGrowingUnitService.execute).toHaveBeenCalledWith({
+				growingUnitAggregate: mockGrowingUnit,
+				plantId,
+			});
+			expect(mockQueryBus.execute).toHaveBeenCalledWith(
+				expect.any(LocationViewModelFindByIdQuery),
 			);
-			expect(mockGrowingUnitReadRepository.save).toHaveBeenCalled();
-			expect(mockGrowingUnitReadRepository.save).toHaveBeenCalledTimes(1);
+			expect(mockPlantViewModelBuilder.reset).toHaveBeenCalled();
+			expect(mockPlantViewModelBuilder.fromEntity).toHaveBeenCalledWith(mockPlant);
+			expect(mockPlantViewModelBuilder.build).toHaveBeenCalled();
+			expect(mockPlantReadRepository.save).toHaveBeenCalledWith(mockViewModel);
+			expect(mockPlantReadRepository.save).toHaveBeenCalledTimes(1);
 		});
 
 		it('should not throw when an error occurs', async () => {
 			const growingUnitId = '123e4567-e89b-12d3-a456-426614174000';
 			const plantId = '223e4567-e89b-12d3-a456-426614174000';
-			const event = new GrowingUnitPlantAddedEvent(
+
+			const event = new PlantCreatedEvent(
 				{
 					aggregateRootId: growingUnitId,
-					aggregateRootType: GrowingUnitAggregate.name,
+					aggregateRootType: 'GrowingUnitAggregate',
 					entityId: plantId,
-					entityType: PlantEntity.name,
-					eventType: GrowingUnitPlantAddedEvent.name,
+					entityType: 'PlantEntity',
+					eventType: 'PlantCreatedEvent',
 				},
 				{
-					plant: {
-						id: plantId,
-						name: 'Basil',
-						species: 'Ocimum basilicum',
-						plantedDate: null,
-						notes: null,
-						status: PlantStatusEnum.PLANTED,
-					},
+					id: plantId,
+					name: 'Basil',
+					species: 'Ocimum basilicum',
+					plantedDate: null,
+					notes: null,
+					status: PlantStatusEnum.PLANTED,
 				},
 			);
 
@@ -277,7 +212,7 @@ describe('GrowingUnitPlantAddedEventHandler', () => {
 			);
 
 			await expect(handler.handle(event)).resolves.not.toThrow();
-			expect(mockGrowingUnitReadRepository.save).not.toHaveBeenCalled();
+			expect(mockPlantReadRepository.save).not.toHaveBeenCalled();
 		});
 	});
 });

--- a/apps/api/src/core/plant-context/application/event-handlers/plant/plant-deleted/plant-deleted.event-handler.spec.ts
+++ b/apps/api/src/core/plant-context/application/event-handlers/plant/plant-deleted/plant-deleted.event-handler.spec.ts
@@ -1,0 +1,100 @@
+import { Test } from '@nestjs/testing';
+
+import { PlantDeletedEventHandler } from '@/core/plant-context/application/event-handlers/plant/plant-deleted/plant-deleted.event-handler';
+import { PlantDeletedEvent } from '@/core/plant-context/application/events/plant/plant-deleted/plant-deleted.event';
+import {
+	IPlantReadRepository,
+	PLANT_READ_REPOSITORY_TOKEN,
+} from '@/core/plant-context/domain/repositories/plant/plant-read/plant-read.repository';
+import { PlantStatusEnum } from '@/core/plant-context/domain/enums/plant/plant-status/plant-status.enum';
+
+describe('PlantDeletedEventHandler', () => {
+	let handler: PlantDeletedEventHandler;
+	let mockPlantReadRepository: jest.Mocked<IPlantReadRepository>;
+
+	beforeEach(async () => {
+		mockPlantReadRepository = {
+			findById: jest.fn(),
+			findByCriteria: jest.fn(),
+			save: jest.fn(),
+			delete: jest.fn(),
+		} as unknown as jest.Mocked<IPlantReadRepository>;
+
+		const module = await Test.createTestingModule({
+			providers: [
+				PlantDeletedEventHandler,
+				{
+					provide: PLANT_READ_REPOSITORY_TOKEN,
+					useValue: mockPlantReadRepository,
+				},
+			],
+		}).compile();
+
+		handler = module.get<PlantDeletedEventHandler>(PlantDeletedEventHandler);
+	});
+
+	afterEach(() => {
+		jest.clearAllMocks();
+	});
+
+	describe('handle', () => {
+		it('should delete plant view model when event is handled', async () => {
+			const growingUnitId = '123e4567-e89b-12d3-a456-426614174000';
+			const plantId = '223e4567-e89b-12d3-a456-426614174000';
+
+			const event = new PlantDeletedEvent(
+				{
+					aggregateRootId: growingUnitId,
+					aggregateRootType: 'GrowingUnitAggregate',
+					entityId: plantId,
+					entityType: 'PlantEntity',
+					eventType: 'PlantDeletedEvent',
+				},
+				{
+					id: plantId,
+					name: 'Basil',
+					species: 'Ocimum basilicum',
+					plantedDate: null,
+					notes: null,
+					status: PlantStatusEnum.PLANTED,
+				},
+			);
+
+			mockPlantReadRepository.delete.mockResolvedValue(undefined);
+
+			await handler.handle(event);
+
+			expect(mockPlantReadRepository.delete).toHaveBeenCalledWith(plantId);
+			expect(mockPlantReadRepository.delete).toHaveBeenCalledTimes(1);
+		});
+
+		it('should not throw when an error occurs', async () => {
+			const growingUnitId = '123e4567-e89b-12d3-a456-426614174000';
+			const plantId = '223e4567-e89b-12d3-a456-426614174000';
+
+			const event = new PlantDeletedEvent(
+				{
+					aggregateRootId: growingUnitId,
+					aggregateRootType: 'GrowingUnitAggregate',
+					entityId: plantId,
+					entityType: 'PlantEntity',
+					eventType: 'PlantDeletedEvent',
+				},
+				{
+					id: plantId,
+					name: 'Basil',
+					species: 'Ocimum basilicum',
+					plantedDate: null,
+					notes: null,
+					status: PlantStatusEnum.PLANTED,
+				},
+			);
+
+			mockPlantReadRepository.delete.mockRejectedValue(
+				new Error('Database error'),
+			);
+
+			await expect(handler.handle(event)).resolves.not.toThrow();
+		});
+	});
+});

--- a/apps/api/src/core/plant-context/application/event-handlers/plant/plant-deleted/plant-deleted.event-handler.ts
+++ b/apps/api/src/core/plant-context/application/event-handlers/plant/plant-deleted/plant-deleted.event-handler.ts
@@ -31,13 +31,20 @@ export class PlantDeletedEventHandler
 	 * @param event - The PlantDeletedEvent event to handle
 	 */
 	async handle(event: PlantDeletedEvent) {
-		this.logger.log(`Handling plant deleted event: ${event.entityId}`);
+		try {
+			this.logger.log(`Handling plant deleted event: ${event.entityId}`);
 
-		this.logger.debug(
-			`Plant deleted event data: ${JSON.stringify(event.data)}`,
-		);
+			this.logger.debug(
+				`Plant deleted event data: ${JSON.stringify(event.data)}`,
+			);
 
-		// 01: Delete the plant view model
-		await this.plantReadRepository.delete(event.entityId);
+			// 01: Delete the plant view model
+			await this.plantReadRepository.delete(event.entityId);
+		} catch (error) {
+			this.logger.error(
+				`Failed to handle plant deleted event: ${event.entityId}`,
+				error,
+			);
+		}
 	}
 }

--- a/apps/api/src/core/plant-context/application/event-handlers/plant/plant-updated/plant-updated.event-handler.spec.ts
+++ b/apps/api/src/core/plant-context/application/event-handlers/plant/plant-updated/plant-updated.event-handler.spec.ts
@@ -1,15 +1,14 @@
 import { Test } from '@nestjs/testing';
 import { QueryBus } from '@nestjs/cqrs';
 
-import { GrowingUnitPlantAddedEventHandler } from '@/core/plant-context/application/event-handlers/growing-unit/growing-unit-plant-added/growing-unit-added.event-handler';
-import { GrowingUnitPlantAddedEvent } from '@/core/plant-context/domain/events/growing-unit/growing-unit/growing-unit-plant-added/growing-unit-plant-added.event';
+import { PlantUpdatedEventHandler } from '@/core/plant-context/application/event-handlers/plant/plant-updated/plant-updated.event-handler';
+import { PlantUpdatedEvent } from '@/core/plant-context/application/events/plant/plant-updated/plant-updated.event';
 import { AssertGrowingUnitExistsService } from '@/core/plant-context/application/services/growing-unit/assert-growing-unit-exists/assert-growing-unit-exists.service';
 import { AssertPlantExistsInGrowingUnitService } from '@/core/plant-context/application/services/growing-unit/assert-plant-exists-in-growing-unit/assert-plant-exists-in-growing-unit.service';
 import { GrowingUnitAggregate } from '@/core/plant-context/domain/aggregates/growing-unit/growing-unit.aggregate';
 import { PlantEntity } from '@/core/plant-context/domain/entities/plant/plant.entity';
 import { GrowingUnitTypeEnum } from '@/core/plant-context/domain/enums/growing-unit/growing-unit-type/growing-unit-type.enum';
 import { PlantStatusEnum } from '@/core/plant-context/domain/enums/plant/plant-status/plant-status.enum';
-import { LocationViewModel } from '@/core/plant-context/domain/view-models/location/location.view-model';
 import { GrowingUnitViewModelBuilder } from '@/core/plant-context/domain/builders/growing-unit/growing-unit-view-model.builder';
 import { PlantViewModelBuilder } from '@/core/plant-context/domain/builders/plant/plant-view-model.builder';
 import {
@@ -17,23 +16,25 @@ import {
 	IGrowingUnitReadRepository,
 } from '@/core/plant-context/domain/repositories/growing-unit/growing-unit-read/growing-unit-read.repository';
 import {
-	PLANT_READ_REPOSITORY_TOKEN,
 	IPlantReadRepository,
+	PLANT_READ_REPOSITORY_TOKEN,
 } from '@/core/plant-context/domain/repositories/plant/plant-read/plant-read.repository';
+import { LocationViewModel } from '@/core/plant-context/domain/view-models/location/location.view-model';
+import { GrowingUnitViewModel } from '@/core/plant-context/domain/view-models/growing-unit/growing-unit.view-model';
+import { PlantViewModel } from '@/core/plant-context/domain/view-models/plant/plant.view-model';
 import { GrowingUnitCapacityValueObject } from '@/core/plant-context/domain/value-objects/growing-unit/growing-unit-capacity/growing-unit-capacity.vo';
 import { GrowingUnitNameValueObject } from '@/core/plant-context/domain/value-objects/growing-unit/growing-unit-name/growing-unit-name.vo';
 import { GrowingUnitTypeValueObject } from '@/core/plant-context/domain/value-objects/growing-unit/growing-unit-type/growing-unit-type.vo';
 import { PlantNameValueObject } from '@/core/plant-context/domain/value-objects/plant/plant-name/plant-name.vo';
 import { PlantSpeciesValueObject } from '@/core/plant-context/domain/value-objects/plant/plant-species/plant-species.vo';
 import { PlantStatusValueObject } from '@/core/plant-context/domain/value-objects/plant/plant-status/plant-status.vo';
-import { GrowingUnitViewModel } from '@/core/plant-context/domain/view-models/growing-unit/growing-unit.view-model';
-import { PlantViewModel } from '@/core/plant-context/domain/view-models/plant/plant.view-model';
 import { GrowingUnitUuidValueObject } from '@/shared/domain/value-objects/identifiers/growing-unit-uuid/growing-unit-uuid.vo';
 import { LocationUuidValueObject } from '@/shared/domain/value-objects/identifiers/location-uuid/location-uuid.vo';
 import { PlantUuidValueObject } from '@/shared/domain/value-objects/identifiers/plant-uuid/plant-uuid.vo';
+import { LocationViewModelFindByIdQuery } from '@/core/location-context/application/queries/location/location-view-model-find-by-id/location-view-model-find-by-id.query';
 
-describe('GrowingUnitPlantAddedEventHandler', () => {
-	let handler: GrowingUnitPlantAddedEventHandler;
+describe('PlantUpdatedEventHandler', () => {
+	let handler: PlantUpdatedEventHandler;
 	let mockGrowingUnitReadRepository: jest.Mocked<IGrowingUnitReadRepository>;
 	let mockPlantReadRepository: jest.Mocked<IPlantReadRepository>;
 	let mockAssertGrowingUnitExistsService: jest.Mocked<AssertGrowingUnitExistsService>;
@@ -68,33 +69,14 @@ describe('GrowingUnitPlantAddedEventHandler', () => {
 		mockGrowingUnitViewModelBuilder = {
 			reset: jest.fn().mockReturnThis(),
 			fromAggregate: jest.fn().mockReturnThis(),
-			withId: jest.fn().mockReturnThis(),
 			withLocation: jest.fn().mockReturnThis(),
-			withName: jest.fn().mockReturnThis(),
-			withType: jest.fn().mockReturnThis(),
-			withCapacity: jest.fn().mockReturnThis(),
-			withDimensions: jest.fn().mockReturnThis(),
-			withPlants: jest.fn().mockReturnThis(),
-			withRemainingCapacity: jest.fn().mockReturnThis(),
-			withNumberOfPlants: jest.fn().mockReturnThis(),
-			withVolume: jest.fn().mockReturnThis(),
-			withCreatedAt: jest.fn().mockReturnThis(),
-			withUpdatedAt: jest.fn().mockReturnThis(),
 			build: jest.fn(),
 		} as unknown as jest.Mocked<GrowingUnitViewModelBuilder>;
 
 		mockPlantViewModelBuilder = {
 			reset: jest.fn().mockReturnThis(),
 			fromEntity: jest.fn().mockReturnThis(),
-			withId: jest.fn().mockReturnThis(),
 			withGrowingUnitId: jest.fn().mockReturnThis(),
-			withName: jest.fn().mockReturnThis(),
-			withSpecies: jest.fn().mockReturnThis(),
-			withPlantedDate: jest.fn().mockReturnThis(),
-			withNotes: jest.fn().mockReturnThis(),
-			withStatus: jest.fn().mockReturnThis(),
-			withCreatedAt: jest.fn().mockReturnThis(),
-			withUpdatedAt: jest.fn().mockReturnThis(),
 			withLocation: jest.fn().mockReturnThis(),
 			withGrowingUnit: jest.fn().mockReturnThis(),
 			build: jest.fn(),
@@ -106,7 +88,7 @@ describe('GrowingUnitPlantAddedEventHandler', () => {
 
 		const module = await Test.createTestingModule({
 			providers: [
-				GrowingUnitPlantAddedEventHandler,
+				PlantUpdatedEventHandler,
 				{
 					provide: GROWING_UNIT_READ_REPOSITORY_TOKEN,
 					useValue: mockGrowingUnitReadRepository,
@@ -138,9 +120,7 @@ describe('GrowingUnitPlantAddedEventHandler', () => {
 			],
 		}).compile();
 
-		handler = module.get<GrowingUnitPlantAddedEventHandler>(
-			GrowingUnitPlantAddedEventHandler,
-		);
+		handler = module.get<PlantUpdatedEventHandler>(PlantUpdatedEventHandler);
 	});
 
 	afterEach(() => {
@@ -148,27 +128,26 @@ describe('GrowingUnitPlantAddedEventHandler', () => {
 	});
 
 	describe('handle', () => {
-		it('should update growing unit view model when plant is added', async () => {
+		it('should update and save plant and growing unit view models when event is handled', async () => {
 			const growingUnitId = '123e4567-e89b-12d3-a456-426614174000';
 			const locationId = '323e4567-e89b-12d3-a456-426614174000';
 			const plantId = '223e4567-e89b-12d3-a456-426614174000';
-			const event = new GrowingUnitPlantAddedEvent(
+
+			const event = new PlantUpdatedEvent(
 				{
 					aggregateRootId: growingUnitId,
-					aggregateRootType: GrowingUnitAggregate.name,
+					aggregateRootType: 'GrowingUnitAggregate',
 					entityId: plantId,
-					entityType: PlantEntity.name,
-					eventType: GrowingUnitPlantAddedEvent.name,
+					entityType: 'PlantEntity',
+					eventType: 'PlantUpdatedEvent',
 				},
 				{
-					plant: {
-						id: plantId,
-						name: 'Basil',
-						species: 'Ocimum basilicum',
-						plantedDate: null,
-						notes: null,
-						status: PlantStatusEnum.PLANTED,
-					},
+					id: plantId,
+					name: 'Basil Updated',
+					species: 'Ocimum basilicum',
+					plantedDate: null,
+					notes: 'Updated notes',
+					status: PlantStatusEnum.PLANTED,
 				},
 			);
 
@@ -182,6 +161,15 @@ describe('GrowingUnitPlantAddedEventHandler', () => {
 				plants: [],
 			});
 
+			const mockPlant = new PlantEntity({
+				id: new PlantUuidValueObject(plantId),
+				name: new PlantNameValueObject('Basil Updated'),
+				species: new PlantSpeciesValueObject('Ocimum basilicum'),
+				plantedDate: null,
+				notes: null,
+				status: new PlantStatusValueObject(PlantStatusEnum.PLANTED),
+			});
+
 			const now = new Date();
 			const location = new LocationViewModel({
 				id: locationId,
@@ -192,7 +180,19 @@ describe('GrowingUnitPlantAddedEventHandler', () => {
 				updatedAt: now,
 			});
 
-			const mockViewModel = new GrowingUnitViewModel({
+			const mockPlantViewModel = new PlantViewModel({
+				id: plantId,
+				growingUnitId: growingUnitId,
+				name: 'Basil Updated',
+				species: 'Ocimum basilicum',
+				plantedDate: null,
+				notes: 'Updated notes',
+				status: PlantStatusEnum.PLANTED,
+				createdAt: now,
+				updatedAt: now,
+			});
+
+			const mockGrowingUnitViewModel = new GrowingUnitViewModel({
 				id: growingUnitId,
 				location,
 				name: 'Garden Bed 1',
@@ -200,75 +200,54 @@ describe('GrowingUnitPlantAddedEventHandler', () => {
 				capacity: 10,
 				dimensions: null,
 				plants: [],
-				numberOfPlants: 1,
-				remainingCapacity: 9,
+				numberOfPlants: 0,
+				remainingCapacity: 10,
 				volume: 0,
 				createdAt: now,
 				updatedAt: now,
 			});
 
-			const mockPlant = new PlantEntity({
-				id: new PlantUuidValueObject(plantId),
-				name: new PlantNameValueObject('Basil'),
-				species: new PlantSpeciesValueObject('Ocimum basilicum'),
-				plantedDate: null,
-				notes: null,
-				status: new PlantStatusValueObject(PlantStatusEnum.PLANTED),
-			});
-
-			mockAssertGrowingUnitExistsService.execute.mockResolvedValue(
-				mockGrowingUnit,
-			);
-			mockAssertPlantExistsInGrowingUnitService.execute.mockResolvedValue(
-				mockPlant,
-			);
+			mockAssertGrowingUnitExistsService.execute.mockResolvedValue(mockGrowingUnit);
+			mockAssertPlantExistsInGrowingUnitService.execute.mockResolvedValue(mockPlant);
 			mockQueryBus.execute.mockResolvedValue(location);
-			mockPlantViewModelBuilder.build.mockReturnValue(
-				new PlantViewModel({
-					id: plantId,
-					growingUnitId: growingUnitId,
-					name: 'Basil',
-					species: 'Ocimum basilicum',
-					plantedDate: null,
-					notes: null,
-					status: PlantStatusEnum.PLANTED,
-					createdAt: now,
-					updatedAt: now,
-				}),
-			);
-			mockGrowingUnitViewModelBuilder.build.mockReturnValue(mockViewModel);
+			mockPlantViewModelBuilder.build.mockReturnValue(mockPlantViewModel);
+			mockGrowingUnitViewModelBuilder.build.mockReturnValue(mockGrowingUnitViewModel);
 			mockPlantReadRepository.save.mockResolvedValue(undefined);
 			mockGrowingUnitReadRepository.save.mockResolvedValue(undefined);
 
 			await handler.handle(event);
 
-			expect(mockAssertGrowingUnitExistsService.execute).toHaveBeenCalledWith(
-				growingUnitId,
+			expect(mockAssertGrowingUnitExistsService.execute).toHaveBeenCalledWith(growingUnitId);
+			expect(mockAssertPlantExistsInGrowingUnitService.execute).toHaveBeenCalledWith({
+				growingUnitAggregate: mockGrowingUnit,
+				plantId,
+			});
+			expect(mockQueryBus.execute).toHaveBeenCalledWith(
+				expect.any(LocationViewModelFindByIdQuery),
 			);
-			expect(mockGrowingUnitReadRepository.save).toHaveBeenCalled();
-			expect(mockGrowingUnitReadRepository.save).toHaveBeenCalledTimes(1);
+			expect(mockPlantReadRepository.save).toHaveBeenCalledWith(mockPlantViewModel);
+			expect(mockGrowingUnitReadRepository.save).toHaveBeenCalledWith(mockGrowingUnitViewModel);
 		});
 
 		it('should not throw when an error occurs', async () => {
 			const growingUnitId = '123e4567-e89b-12d3-a456-426614174000';
 			const plantId = '223e4567-e89b-12d3-a456-426614174000';
-			const event = new GrowingUnitPlantAddedEvent(
+
+			const event = new PlantUpdatedEvent(
 				{
 					aggregateRootId: growingUnitId,
-					aggregateRootType: GrowingUnitAggregate.name,
+					aggregateRootType: 'GrowingUnitAggregate',
 					entityId: plantId,
-					entityType: PlantEntity.name,
-					eventType: GrowingUnitPlantAddedEvent.name,
+					entityType: 'PlantEntity',
+					eventType: 'PlantUpdatedEvent',
 				},
 				{
-					plant: {
-						id: plantId,
-						name: 'Basil',
-						species: 'Ocimum basilicum',
-						plantedDate: null,
-						notes: null,
-						status: PlantStatusEnum.PLANTED,
-					},
+					id: plantId,
+					name: 'Basil Updated',
+					species: 'Ocimum basilicum',
+					plantedDate: null,
+					notes: 'Updated notes',
+					status: PlantStatusEnum.PLANTED,
 				},
 			);
 
@@ -277,6 +256,7 @@ describe('GrowingUnitPlantAddedEventHandler', () => {
 			);
 
 			await expect(handler.handle(event)).resolves.not.toThrow();
+			expect(mockPlantReadRepository.save).not.toHaveBeenCalled();
 			expect(mockGrowingUnitReadRepository.save).not.toHaveBeenCalled();
 		});
 	});

--- a/apps/api/src/core/plant-context/application/event-handlers/plant/plant-updated/plant-updated.event-handler.ts
+++ b/apps/api/src/core/plant-context/application/event-handlers/plant/plant-updated/plant-updated.event-handler.ts
@@ -48,59 +48,66 @@ export class PlantUpdatedEventHandler
 	 * @param event - The PlantUpdatedEvent event to handle
 	 */
 	async handle(event: PlantUpdatedEvent) {
-		this.logger.log(`Handling plant updated event: ${event.entityId}`);
+		try {
+			this.logger.log(`Handling plant updated event: ${event.entityId}`);
 
-		this.logger.debug(
-			`Plant updated event data: ${JSON.stringify(event.data)}`,
-		);
+			this.logger.debug(
+				`Plant updated event data: ${JSON.stringify(event.data)}`,
+			);
 
-		// 01: Get the growing unit aggregate to have the complete state
-		const growingUnitAggregate =
-			await this.assertGrowingUnitExistsService.execute(event.aggregateRootId);
+			// 01: Get the growing unit aggregate to have the complete state
+			const growingUnitAggregate =
+				await this.assertGrowingUnitExistsService.execute(event.aggregateRootId);
 
-		// 02: Get the plant entity from the growing unit aggregate
-		const plantEntity =
-			await this.assertPlantExistsInGrowingUnitService.execute({
-				growingUnitAggregate,
-				plantId: event.entityId,
-			});
+			// 02: Get the plant entity from the growing unit aggregate
+			const plantEntity =
+				await this.assertPlantExistsInGrowingUnitService.execute({
+					growingUnitAggregate,
+					plantId: event.entityId,
+				});
 
-		// 03: Get the location view model
-		const locationViewModel = await this.queryBus.execute(
-			new LocationViewModelFindByIdQuery({
-				id: growingUnitAggregate.locationId.value,
-			}),
-		);
+			// 03: Get the location view model
+			const locationViewModel = await this.queryBus.execute(
+				new LocationViewModelFindByIdQuery({
+					id: growingUnitAggregate.locationId.value,
+				}),
+			);
 
-		// 04: Create the growing unit reference with basic information
-		const growingUnitReference = {
-			id: growingUnitAggregate.id.value,
-			name: growingUnitAggregate.name.value,
-			type: growingUnitAggregate.type.value,
-			capacity: growingUnitAggregate.capacity.value,
-		};
+			// 04: Create the growing unit reference with basic information
+			const growingUnitReference = {
+				id: growingUnitAggregate.id.value,
+				name: growingUnitAggregate.name.value,
+				type: growingUnitAggregate.type.value,
+				capacity: growingUnitAggregate.capacity.value,
+			};
 
-		// 05: Create the updated plant view model
-		const plantViewModel: PlantViewModel = this.plantViewModelBuilder
-			.reset()
-			.fromEntity(plantEntity)
-			.withGrowingUnitId(growingUnitAggregate.id.value)
-			.withLocation(locationViewModel)
-			.withGrowingUnit(growingUnitReference)
-			.build();
-
-		// 06: Create the updated growing unit view model from the aggregate
-		const growingUnitViewModel: GrowingUnitViewModel =
-			this.growingUnitViewModelBuilder
+			// 05: Create the updated plant view model
+			const plantViewModel: PlantViewModel = this.plantViewModelBuilder
 				.reset()
-				.fromAggregate(growingUnitAggregate)
+				.fromEntity(plantEntity)
+				.withGrowingUnitId(growingUnitAggregate.id.value)
 				.withLocation(locationViewModel)
+				.withGrowingUnit(growingUnitReference)
 				.build();
 
-		// 07: Save both view models
-		await Promise.all([
-			this.plantReadRepository.save(plantViewModel),
-			this.growingUnitReadRepository.save(growingUnitViewModel),
-		]);
+			// 06: Create the updated growing unit view model from the aggregate
+			const growingUnitViewModel: GrowingUnitViewModel =
+				this.growingUnitViewModelBuilder
+					.reset()
+					.fromAggregate(growingUnitAggregate)
+					.withLocation(locationViewModel)
+					.build();
+
+			// 07: Save both view models
+			await Promise.all([
+				this.plantReadRepository.save(plantViewModel),
+				this.growingUnitReadRepository.save(growingUnitViewModel),
+			]);
+		} catch (error) {
+			this.logger.error(
+				`Failed to handle plant updated event: ${event.entityId}`,
+				error,
+			);
+		}
 	}
 }

--- a/apps/api/src/core/plant-species-context/infrastructure/event-handlers/plant-species/plant-species-created/plant-species-created.event-handler.spec.ts
+++ b/apps/api/src/core/plant-species-context/infrastructure/event-handlers/plant-species/plant-species-created/plant-species-created.event-handler.spec.ts
@@ -188,5 +188,51 @@ describe('PlantSpeciesCreatedEventHandler', () => {
 			expect(mockPlantSpeciesReadRepository.save).toHaveBeenCalledWith(mockViewModel);
 			expect(mockPlantSpeciesReadRepository.save).toHaveBeenCalledTimes(1);
 		});
+
+		it('should not throw when an error occurs', async () => {
+			const plantSpeciesId = '123e4567-e89b-12d3-a456-426614174000';
+			const now = new Date();
+
+			const event = new PlantSpeciesCreatedEvent(
+				{
+					aggregateRootId: plantSpeciesId,
+					aggregateRootType: 'PlantSpeciesAggregate',
+					entityId: plantSpeciesId,
+					entityType: 'PlantSpeciesAggregate',
+					eventType: 'PlantSpeciesCreatedEvent',
+				},
+				{
+					id: plantSpeciesId,
+					commonName: 'Tomato',
+					scientificName: 'Solanum lycopersicum',
+					family: 'Solanaceae',
+					description: 'A common garden vegetable.',
+					category: PlantSpeciesCategoryEnum.VEGETABLE,
+					difficulty: PlantSpeciesDifficultyEnum.EASY,
+					growthRate: PlantSpeciesGrowthRateEnum.FAST,
+					lightRequirements: PlantSpeciesLightRequirementsEnum.FULL_SUN,
+					waterRequirements: PlantSpeciesWaterRequirementsEnum.MEDIUM,
+					temperatureRange: { min: 15, max: 30 },
+					humidityRequirements: PlantSpeciesHumidityRequirementsEnum.MEDIUM,
+					soilType: PlantSpeciesSoilTypeEnum.LOAMY,
+					phRange: { min: 6.0, max: 7.0 },
+					matureSize: { height: 150, width: 60 },
+					growthTime: 90,
+					tags: ['edible', 'garden'],
+					isVerified: true,
+					contributorId: null,
+					createdAt: now,
+					updatedAt: now,
+					deletedAt: null,
+				},
+			);
+
+			mockAssertPlantSpeciesExistsService.execute.mockRejectedValue(
+				new Error('Database error'),
+			);
+
+			await expect(handler.handle(event)).resolves.not.toThrow();
+			expect(mockPlantSpeciesReadRepository.save).not.toHaveBeenCalled();
+		});
 	});
 });

--- a/apps/api/src/core/plant-species-context/infrastructure/event-handlers/plant-species/plant-species-created/plant-species-created.event-handler.ts
+++ b/apps/api/src/core/plant-species-context/infrastructure/event-handlers/plant-species/plant-species-created/plant-species-created.event-handler.ts
@@ -35,24 +35,31 @@ export class PlantSpeciesCreatedEventHandler
 	 * @param event - The PlantSpeciesCreatedEvent event to handle
 	 */
 	async handle(event: PlantSpeciesCreatedEvent) {
-		this.logger.log(`Handling plant species created event: ${event.entityId}`);
+		try {
+			this.logger.log(`Handling plant species created event: ${event.entityId}`);
 
-		this.logger.debug(
-			`Plant species created event data: ${JSON.stringify(event.data)}`,
-		);
+			this.logger.debug(
+				`Plant species created event data: ${JSON.stringify(event.data)}`,
+			);
 
-		// 01: Get the plant species aggregate to have the complete state
-		const plantSpeciesAggregate =
-			await this.assertPlantSpeciesExistsService.execute(event.entityId);
+			// 01: Get the plant species aggregate to have the complete state
+			const plantSpeciesAggregate =
+				await this.assertPlantSpeciesExistsService.execute(event.entityId);
 
-		// 02: Create the plant species view model from the aggregate
-		const plantSpeciesViewModel: PlantSpeciesViewModel =
-			this.plantSpeciesViewModelBuilder
-				.reset()
-				.fromAggregate(plantSpeciesAggregate)
-				.build();
+			// 02: Create the plant species view model from the aggregate
+			const plantSpeciesViewModel: PlantSpeciesViewModel =
+				this.plantSpeciesViewModelBuilder
+					.reset()
+					.fromAggregate(plantSpeciesAggregate)
+					.build();
 
-		// 03: Save the plant species view model
-		await this.plantSpeciesReadRepository.save(plantSpeciesViewModel);
+			// 03: Save the plant species view model
+			await this.plantSpeciesReadRepository.save(plantSpeciesViewModel);
+		} catch (error) {
+			this.logger.error(
+				`Failed to handle plant species created event: ${event.entityId}`,
+				error,
+			);
+		}
 	}
 }

--- a/apps/api/src/core/plant-species-context/infrastructure/event-handlers/plant-species/plant-species-deleted/plant-species-deleted.event-handler.spec.ts
+++ b/apps/api/src/core/plant-species-context/infrastructure/event-handlers/plant-species/plant-species-deleted/plant-species-deleted.event-handler.spec.ts
@@ -91,5 +91,50 @@ describe('PlantSpeciesDeletedEventHandler', () => {
 			expect(mockPlantSpeciesReadRepository.delete).toHaveBeenCalledWith(plantSpeciesId);
 			expect(mockPlantSpeciesReadRepository.delete).toHaveBeenCalledTimes(1);
 		});
+
+		it('should not throw when an error occurs', async () => {
+			const plantSpeciesId = '123e4567-e89b-12d3-a456-426614174000';
+			const now = new Date();
+
+			const event = new PlantSpeciesDeletedEvent(
+				{
+					aggregateRootId: plantSpeciesId,
+					aggregateRootType: 'PlantSpeciesAggregate',
+					entityId: plantSpeciesId,
+					entityType: 'PlantSpeciesAggregate',
+					eventType: 'PlantSpeciesDeletedEvent',
+				},
+				{
+					id: plantSpeciesId,
+					commonName: 'Tomato',
+					scientificName: 'Solanum lycopersicum',
+					family: 'Solanaceae',
+					description: 'A common garden vegetable.',
+					category: PlantSpeciesCategoryEnum.VEGETABLE,
+					difficulty: PlantSpeciesDifficultyEnum.EASY,
+					growthRate: PlantSpeciesGrowthRateEnum.FAST,
+					lightRequirements: PlantSpeciesLightRequirementsEnum.FULL_SUN,
+					waterRequirements: PlantSpeciesWaterRequirementsEnum.MEDIUM,
+					temperatureRange: { min: 15, max: 30 },
+					humidityRequirements: PlantSpeciesHumidityRequirementsEnum.MEDIUM,
+					soilType: PlantSpeciesSoilTypeEnum.LOAMY,
+					phRange: { min: 6.0, max: 7.0 },
+					matureSize: { height: 150, width: 60 },
+					growthTime: 90,
+					tags: ['edible', 'garden'],
+					isVerified: true,
+					contributorId: null,
+					createdAt: now,
+					updatedAt: now,
+					deletedAt: now,
+				},
+			);
+
+			mockPlantSpeciesReadRepository.delete.mockRejectedValue(
+				new Error('Database error'),
+			);
+
+			await expect(handler.handle(event)).resolves.not.toThrow();
+		});
 	});
 });

--- a/apps/api/src/core/plant-species-context/infrastructure/event-handlers/plant-species/plant-species-deleted/plant-species-deleted.event-handler.ts
+++ b/apps/api/src/core/plant-species-context/infrastructure/event-handlers/plant-species/plant-species-deleted/plant-species-deleted.event-handler.ts
@@ -30,13 +30,20 @@ export class PlantSpeciesDeletedEventHandler
 	 * @param event - The PlantSpeciesDeletedEvent event to handle
 	 */
 	async handle(event: PlantSpeciesDeletedEvent) {
-		this.logger.log(`Handling plant species deleted event: ${event.entityId}`);
+		try {
+			this.logger.log(`Handling plant species deleted event: ${event.entityId}`);
 
-		this.logger.debug(
-			`Plant species deleted event data: ${JSON.stringify(event.data)}`,
-		);
+			this.logger.debug(
+				`Plant species deleted event data: ${JSON.stringify(event.data)}`,
+			);
 
-		// 01: Delete the plant species view model
-		await this.plantSpeciesReadRepository.delete(event.entityId);
+			// 01: Delete the plant species view model
+			await this.plantSpeciesReadRepository.delete(event.entityId);
+		} catch (error) {
+			this.logger.error(
+				`Failed to handle plant species deleted event: ${event.entityId}`,
+				error,
+			);
+		}
 	}
 }

--- a/apps/api/src/core/plant-species-context/infrastructure/event-handlers/plant-species/plant-species-updated/plant-species-updated.event-handler.spec.ts
+++ b/apps/api/src/core/plant-species-context/infrastructure/event-handlers/plant-species/plant-species-updated/plant-species-updated.event-handler.spec.ts
@@ -188,5 +188,51 @@ describe('PlantSpeciesUpdatedEventHandler', () => {
 			expect(mockPlantSpeciesReadRepository.save).toHaveBeenCalledWith(mockViewModel);
 			expect(mockPlantSpeciesReadRepository.save).toHaveBeenCalledTimes(1);
 		});
+
+		it('should not throw when an error occurs', async () => {
+			const plantSpeciesId = '123e4567-e89b-12d3-a456-426614174000';
+			const now = new Date();
+
+			const event = new PlantSpeciesUpdatedEvent(
+				{
+					aggregateRootId: plantSpeciesId,
+					aggregateRootType: 'PlantSpeciesAggregate',
+					entityId: plantSpeciesId,
+					entityType: 'PlantSpeciesAggregate',
+					eventType: 'PlantSpeciesUpdatedEvent',
+				},
+				{
+					id: plantSpeciesId,
+					commonName: 'Tomato Updated',
+					scientificName: 'Solanum lycopersicum',
+					family: 'Solanaceae',
+					description: 'An updated common garden vegetable.',
+					category: PlantSpeciesCategoryEnum.VEGETABLE,
+					difficulty: PlantSpeciesDifficultyEnum.MEDIUM,
+					growthRate: PlantSpeciesGrowthRateEnum.MEDIUM,
+					lightRequirements: PlantSpeciesLightRequirementsEnum.PARTIAL_SUN,
+					waterRequirements: PlantSpeciesWaterRequirementsEnum.HIGH,
+					temperatureRange: { min: 10, max: 35 },
+					humidityRequirements: PlantSpeciesHumidityRequirementsEnum.HIGH,
+					soilType: PlantSpeciesSoilTypeEnum.SANDY,
+					phRange: { min: 5.5, max: 7.5 },
+					matureSize: { height: 180, width: 70 },
+					growthTime: 100,
+					tags: ['edible', 'garden', 'updated'],
+					isVerified: false,
+					contributorId: null,
+					createdAt: now,
+					updatedAt: now,
+					deletedAt: null,
+				},
+			);
+
+			mockAssertPlantSpeciesExistsService.execute.mockRejectedValue(
+				new Error('Database error'),
+			);
+
+			await expect(handler.handle(event)).resolves.not.toThrow();
+			expect(mockPlantSpeciesReadRepository.save).not.toHaveBeenCalled();
+		});
 	});
 });

--- a/apps/api/src/core/plant-species-context/infrastructure/event-handlers/plant-species/plant-species-updated/plant-species-updated.event-handler.ts
+++ b/apps/api/src/core/plant-species-context/infrastructure/event-handlers/plant-species/plant-species-updated/plant-species-updated.event-handler.ts
@@ -35,24 +35,31 @@ export class PlantSpeciesUpdatedEventHandler
 	 * @param event - The PlantSpeciesUpdatedEvent event to handle
 	 */
 	async handle(event: PlantSpeciesUpdatedEvent) {
-		this.logger.log(`Handling plant species updated event: ${event.entityId}`);
+		try {
+			this.logger.log(`Handling plant species updated event: ${event.entityId}`);
 
-		this.logger.debug(
-			`Plant species updated event data: ${JSON.stringify(event.data)}`,
-		);
+			this.logger.debug(
+				`Plant species updated event data: ${JSON.stringify(event.data)}`,
+			);
 
-		// 01: Get the plant species aggregate to have the complete state
-		const plantSpeciesAggregate =
-			await this.assertPlantSpeciesExistsService.execute(event.entityId);
+			// 01: Get the plant species aggregate to have the complete state
+			const plantSpeciesAggregate =
+				await this.assertPlantSpeciesExistsService.execute(event.entityId);
 
-		// 02: Rebuild the plant species view model from the aggregate
-		const plantSpeciesViewModel: PlantSpeciesViewModel =
-			this.plantSpeciesViewModelBuilder
-				.reset()
-				.fromAggregate(plantSpeciesAggregate)
-				.build();
+			// 02: Rebuild the plant species view model from the aggregate
+			const plantSpeciesViewModel: PlantSpeciesViewModel =
+				this.plantSpeciesViewModelBuilder
+					.reset()
+					.fromAggregate(plantSpeciesAggregate)
+					.build();
 
-		// 03: Save the updated plant species view model
-		await this.plantSpeciesReadRepository.save(plantSpeciesViewModel);
+			// 03: Save the updated plant species view model
+			await this.plantSpeciesReadRepository.save(plantSpeciesViewModel);
+		} catch (error) {
+			this.logger.error(
+				`Failed to handle plant species updated event: ${event.entityId}`,
+				error,
+			);
+		}
 	}
 }


### PR DESCRIPTION
Closes #174

Wrap all event handler logic in try-catch blocks to prevent errors from propagating and disrupting the event bus. Errors are now logged with context but never thrown.

Generated with [Claude Code](https://claude.ai/code)